### PR TITLE
Core library improvements: logging fallbacks, UI escape handling, Write-Warning/Error rename

### DIFF
--- a/bin/clean.ps1
+++ b/bin/clean.ps1
@@ -109,7 +109,7 @@ function Main {
     if ($DryRun -or $env:WINMOLE_DRY_RUN -eq "1") {
         Set-DryRunMode -Enabled $true
         Write-Host ""
-        Write-Warning "DRY RUN MODE - No files will be deleted"
+        Write-WinMoleWarning "DRY RUN MODE - No files will be deleted"
     }
     
     # Determine what to clean
@@ -209,7 +209,7 @@ function Main {
             Invoke-SystemCleanup -All
         }
         else {
-            Write-Warning "System cleanup requires admin - skipping"
+            Write-WinMoleWarning "System cleanup requires admin - skipping"
             Write-Info "Run 'winmole clean -System' as Administrator"
         }
     }
@@ -223,7 +223,7 @@ function Main {
             Clear-WindowsUpdateCache
         }
         else {
-            Write-Warning "Windows Update cleanup requires admin - skipping"
+            Write-WinMoleWarning "Windows Update cleanup requires admin - skipping"
         }
     }
     

--- a/bin/optimize.ps1
+++ b/bin/optimize.ps1
@@ -65,7 +65,7 @@ function Optimize-Drives {
     Start-Section "Drive Optimization"
     
     if (-not (Test-IsAdmin)) {
-        Write-Warning "Drive optimization requires administrator privileges"
+        Write-WinMoleWarning "Drive optimization requires administrator privileges"
         Stop-Section
         return
     }
@@ -109,7 +109,7 @@ function Optimize-Drives {
             }
         }
         catch {
-            Write-Warning "Could not optimize $letter : $_"
+            Write-WinMoleWarning "Could not optimize $letter : $_"
         }
     }
     
@@ -166,7 +166,7 @@ function Optimize-Services {
     Start-Section "Windows Services"
     
     if (-not (Test-IsAdmin)) {
-        Write-Warning "Service optimization requires administrator privileges"
+        Write-WinMoleWarning "Service optimization requires administrator privileges"
         Stop-Section
         return
     }
@@ -195,7 +195,7 @@ function Optimize-Services {
                     Write-Success "Disabled $($serviceInfo.Name)"
                 }
                 catch {
-                    Write-Warning "Could not disable $($serviceInfo.Name)"
+                    Write-WinMoleWarning "Could not disable $($serviceInfo.Name)"
                 }
             }
         }
@@ -360,7 +360,7 @@ function Manage-StartupItems {
             Write-Success "Disabled startup: $($startupItem.Name)"
         }
         catch {
-            Write-Warning "Could not disable: $($startupItem.Name)"
+            Write-WinMoleWarning "Could not disable: $($startupItem.Name)"
         }
     }
 }
@@ -377,7 +377,7 @@ function Reset-NetworkConfig {
     Start-Section "Network Reset"
     
     if (-not (Test-IsAdmin)) {
-        Write-Warning "Network reset requires administrator privileges"
+        Write-WinMoleWarning "Network reset requires administrator privileges"
         Stop-Section
         return
     }
@@ -405,7 +405,7 @@ function Reset-NetworkConfig {
     netsh int ip reset | Out-Null
     Write-Success "TCP/IP stack reset"
     
-    Write-Warning "Restart your computer for changes to take effect"
+    Write-WinMoleWarning "Restart your computer for changes to take effect"
     
     Stop-Section
 }
@@ -426,7 +426,7 @@ function Test-SystemHealth {
     foreach ($drive in $drives) {
         $freePercent = [Math]::Round(($drive.FreeSpace / $drive.Size) * 100)
         if ($freePercent -lt 10) {
-            Write-Warning "$($drive.DeviceID) has only $freePercent% free space"
+            Write-WinMoleWarning "$($drive.DeviceID) has only $freePercent% free space"
         }
         else {
             Write-Success "$($drive.DeviceID) has $freePercent% free space"
@@ -437,7 +437,7 @@ function Test-SystemHealth {
     $lastUpdate = (Get-HotFix | Sort-Object InstalledOn -Descending | Select-Object -First 1).InstalledOn
     $daysSinceUpdate = ((Get-Date) - $lastUpdate).Days
     if ($daysSinceUpdate -gt 30) {
-        Write-Warning "Last Windows update was $daysSinceUpdate days ago"
+        Write-WinMoleWarning "Last Windows update was $daysSinceUpdate days ago"
     }
     else {
         Write-Success "Windows updated $daysSinceUpdate days ago"
@@ -451,7 +451,7 @@ function Test-SystemHealth {
             Write-Success "System files are intact"
         }
         else {
-            Write-Warning "System file issues detected - run 'sfc /scannow' as admin"
+            Write-WinMoleWarning "System file issues detected - run 'sfc /scannow' as admin"
         }
     }
     
@@ -496,7 +496,7 @@ function Main {
     if ($DryRun -or $env:WINMOLE_DRY_RUN -eq "1") {
         Set-DryRunMode -Enabled $true
         Write-Host ""
-        Write-Warning "DRY RUN MODE - No changes will be made"
+        Write-WinMoleWarning "DRY RUN MODE - No changes will be made"
     }
     
     # Determine what to run

--- a/bin/purge.ps1
+++ b/bin/purge.ps1
@@ -365,14 +365,14 @@ function Main {
     if ($DryRun -or $env:WINMOLE_DRY_RUN -eq "1") {
         Set-DryRunMode -Enabled $true
         Write-Host ""
-        Write-Warning "DRY RUN MODE - No files will be deleted"
+        Write-WinMoleWarning "DRY RUN MODE - No files will be deleted"
     }
     
     # Determine search path
     $searchPath = if ($Path) { $Path } else { Get-Location }
     
     if (-not (Test-Path $searchPath)) {
-        Write-Error "Path not found: $searchPath"
+        Write-WinMoleError "Path not found: $searchPath"
         return
     }
     

--- a/bin/status.ps1
+++ b/bin/status.ps1
@@ -77,7 +77,7 @@ function Build-StatusTool {
     # Check if Go is installed
     $goCmd = Get-Command "go" -ErrorAction SilentlyContinue
     if (-not $goCmd) {
-        Write-Error "Go is not installed or not in PATH"
+        Write-WinMoleError "Go is not installed or not in PATH"
         Write-Host ""
         Write-Host "  Install Go from: https://go.dev/dl/"
         Write-Host ""
@@ -99,7 +99,7 @@ function Build-StatusTool {
         $buildOutput = & go build -ldflags="-s -w" -o $binaryPath . 2>&1
         
         if ($LASTEXITCODE -ne 0) {
-            Write-Error "Build failed: $buildOutput"
+            Write-WinMoleError "Build failed: $buildOutput"
             return $false
         }
         
@@ -107,7 +107,7 @@ function Build-StatusTool {
         return $true
     }
     catch {
-        Write-Error "Build failed: $_"
+        Write-WinMoleError "Build failed: $_"
         return $false
     }
     finally {
@@ -162,7 +162,7 @@ try {
 }
 catch {
     Write-Host ""
-    Write-Error "An error occurred: $_"
+    Write-WinMoleError "An error occurred: $_"
     Write-Host ""
     exit 1
 }

--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -198,7 +198,7 @@ function Uninstall-Application {
         return $true
     }
     catch {
-        Write-Error "Failed to uninstall $name : $_"
+        Write-WinMoleError "Failed to uninstall $name : $_"
         return $false
     }
 }
@@ -436,7 +436,7 @@ function Main {
     if ($DryRun -or $env:WINMOLE_DRY_RUN -eq "1") {
         Set-DryRunMode -Enabled $true
         Write-Host ""
-        Write-Warning "DRY RUN MODE - No changes will be made"
+        Write-WinMoleWarning "DRY RUN MODE - No changes will be made"
     }
     
     if ($List) {
@@ -484,7 +484,7 @@ function Main {
         $matches = Find-App -SearchTerm $AppName
         
         if ($matches.Count -eq 0) {
-            Write-Error "No applications found matching '$AppName'"
+            Write-WinMoleError "No applications found matching '$AppName'"
             return
         }
         

--- a/lib/clean/dev.ps1
+++ b/lib/clean/dev.ps1
@@ -310,7 +310,7 @@ function Clear-DockerCache {
     # Check if Docker daemon is running
     $dockerRunning = docker info 2>&1
     if ($LASTEXITCODE -ne 0) {
-        Write-Warning "Docker daemon is not running"
+        Write-WinMoleWarning "Docker daemon is not running"
         Stop-Section
         return
     }

--- a/lib/clean/system.ps1
+++ b/lib/clean/system.ps1
@@ -19,7 +19,7 @@ function Clear-SystemCaches {
         Clean Windows system-level caches (requires admin)
     #>
     if (-not (Test-IsAdmin)) {
-        Write-Warning "System cleanup requires administrator privileges"
+        Write-WinMoleWarning "System cleanup requires administrator privileges"
         return
     }
     
@@ -56,7 +56,7 @@ function Clear-SystemLogs {
         Clean Windows system logs (requires admin)
     #>
     if (-not (Test-IsAdmin)) {
-        Write-Warning "System log cleanup requires administrator privileges"
+        Write-WinMoleWarning "System log cleanup requires administrator privileges"
         return
     }
     
@@ -115,7 +115,7 @@ function Clear-MemoryDumps {
         Clean system memory dumps (requires admin)
     #>
     if (-not (Test-IsAdmin)) {
-        Write-Warning "Memory dump cleanup requires administrator privileges"
+        Write-WinMoleWarning "Memory dump cleanup requires administrator privileges"
         return
     }
     
@@ -155,7 +155,7 @@ function Clear-DefenderCache {
         Clean Windows Defender caches and history
     #>
     if (-not (Test-IsAdmin)) {
-        Write-Warning "Defender cleanup requires administrator privileges"
+        Write-WinMoleWarning "Defender cleanup requires administrator privileges"
         return
     }
     
@@ -172,7 +172,7 @@ function Clear-DefenderCache {
     if (Test-Path $quarantine) {
         $quarantineItems = Get-ChildItem -Path $quarantine -Recurse -ErrorAction SilentlyContinue
         if ($quarantineItems) {
-            Write-Warning "Defender quarantine has items - review in Windows Security before cleaning"
+            Write-WinMoleWarning "Defender quarantine has items - review in Windows Security before cleaning"
         }
     }
     
@@ -270,7 +270,7 @@ function Invoke-StorageSense {
     # Check if Storage Sense is available (Windows 10 1809+)
     $storageSenseKey = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\StorageSense\Parameters\StoragePolicy"
     if (-not (Test-Path $storageSenseKey)) {
-        Write-Warning "Storage Sense not available on this system"
+        Write-WinMoleWarning "Storage Sense not available on this system"
         Stop-Section
         return
     }
@@ -284,7 +284,7 @@ function Invoke-StorageSense {
         Write-Success "Storage Sense cleanup triggered"
     }
     else {
-        Write-Warning "Storage Sense executable not found"
+        Write-WinMoleWarning "Storage Sense executable not found"
     }
     
     Stop-Section
@@ -308,7 +308,7 @@ function Invoke-SystemCleanup {
     )
     
     if (-not (Test-IsAdmin)) {
-        Write-Error "System cleanup requires administrator privileges"
+        Write-WinMoleError "System cleanup requires administrator privileges"
         Write-Info "Please run WinMole as Administrator"
         return
     }

--- a/lib/clean/user.ps1
+++ b/lib/clean/user.ps1
@@ -193,7 +193,7 @@ function Clear-ChromeCache {
     # Check if Chrome is running
     $chromeRunning = Get-Process -Name "chrome" -ErrorAction SilentlyContinue
     if ($chromeRunning) {
-        Write-Warning "Chrome is running - some caches skipped"
+        Write-WinMoleWarning "Chrome is running - some caches skipped"
     }
     
     $profiles = Get-ChildItem -Path $chromePath -Directory -ErrorAction SilentlyContinue | 
@@ -227,7 +227,7 @@ function Clear-EdgeCache {
     
     $edgeRunning = Get-Process -Name "msedge" -ErrorAction SilentlyContinue
     if ($edgeRunning) {
-        Write-Warning "Edge is running - some caches skipped"
+        Write-WinMoleWarning "Edge is running - some caches skipped"
     }
     
     $profiles = Get-ChildItem -Path $edgePath -Directory -ErrorAction SilentlyContinue |
@@ -255,7 +255,7 @@ function Clear-FirefoxCache {
     
     $firefoxRunning = Get-Process -Name "firefox" -ErrorAction SilentlyContinue
     if ($firefoxRunning) {
-        Write-Warning "Firefox is running - some caches skipped"
+        Write-WinMoleWarning "Firefox is running - some caches skipped"
     }
     
     $profiles = Get-ChildItem -Path $firefoxPath -Directory -ErrorAction SilentlyContinue
@@ -283,7 +283,7 @@ function Clear-BraveCache {
     
     $braveRunning = Get-Process -Name "brave" -ErrorAction SilentlyContinue
     if ($braveRunning) {
-        Write-Warning "Brave is running - some caches skipped"
+        Write-WinMoleWarning "Brave is running - some caches skipped"
     }
     
     $profiles = Get-ChildItem -Path $bravePath -Directory -ErrorAction SilentlyContinue |
@@ -307,7 +307,7 @@ function Clear-OperaCache {
     
     $operaRunning = Get-Process -Name "opera" -ErrorAction SilentlyContinue
     if ($operaRunning) {
-        Write-Warning "Opera is running - some caches skipped"
+        Write-WinMoleWarning "Opera is running - some caches skipped"
     }
     
     $cachePath = Join-Path $operaPath "Cache"

--- a/lib/core/common.ps1
+++ b/lib/core/common.ps1
@@ -90,7 +90,7 @@ function Request-AdminPrivileges {
         Restarts the script with elevated privileges using UAC
     #>
     if (-not (Test-IsAdmin)) {
-        Write-Warning "Some operations require administrator privileges."
+        Write-WinMoleWarning "Some operations require administrator privileges."
         
         if (Read-Confirmation -Prompt "Restart with admin privileges?" -Default $true) {
             $scriptPath = $MyInvocation.PSCommandPath

--- a/lib/core/log.ps1
+++ b/lib/core/log.ps1
@@ -12,6 +12,46 @@ $script:WINMOLE_LOG_LOADED = $true
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 . "$scriptDir\base.ps1"
 
+# Fallbacks in case base.ps1 did not initialize icons/colors in this scope
+if (-not ($script:Icons -is [hashtable])) {
+    $script:Icons = @{}
+}
+
+$iconDefaults = @{
+    List    = "*"
+    Success = "+"
+    Warning = "!"
+    Error   = "x"
+    DryRun  = ">"
+    Arrow   = ">"
+}
+
+foreach ($key in $iconDefaults.Keys) {
+    if (-not $script:Icons.ContainsKey($key)) {
+        $script:Icons[$key] = $iconDefaults[$key]
+    }
+}
+
+if (-not ($script:Colors -is [hashtable])) {
+    $script:Colors = @{}
+}
+
+$colorDefaults = @{
+    Cyan       = ""
+    Green      = ""
+    Yellow     = ""
+    Red        = ""
+    Gray       = ""
+    PurpleBold = ""
+    NC         = ""
+}
+
+foreach ($key in $colorDefaults.Keys) {
+    if (-not $script:Colors.ContainsKey($key)) {
+        $script:Colors[$key] = $colorDefaults[$key]
+    }
+}
+
 # ============================================================================
 # Log Configuration
 # ============================================================================
@@ -71,19 +111,19 @@ function Write-Success {
     Write-LogMessage -Message $Message -Level "SUCCESS" -Color "Green" -Icon $script:Icons.Success
 }
 
-function Write-Warning {
+function Write-WinMoleWarning {
     <#
     .SYNOPSIS
-        Write a warning message
+        Write a warning message (named to avoid conflict with built-in Write-Warning cmdlet)
     #>
     param([string]$Message)
     Write-LogMessage -Message $Message -Level "WARN" -Color "Yellow" -Icon $script:Icons.Warning
 }
 
-function Write-Error {
+function Write-WinMoleError {
     <#
     .SYNOPSIS
-        Write an error message
+        Write an error message (named to avoid conflict with built-in Write-Error cmdlet)
     #>
     param([string]$Message)
     Write-LogMessage -Message $Message -Level "ERROR" -Color "Red" -Icon $script:Icons.Error
@@ -116,7 +156,7 @@ function Write-DryRun {
 # Section Functions (for progress indication)
 # ============================================================================
 
-$global:WinMoleCurrentSection = @{
+$script:CurrentSection = @{
     Active   = $false
     Activity = $false
     Name     = ""
@@ -129,9 +169,9 @@ function Start-Section {
     #>
     param([string]$Title)
     
-    $global:WinMoleCurrentSection.Active = $true
-    $global:WinMoleCurrentSection.Activity = $false
-    $global:WinMoleCurrentSection.Name = $Title
+    $script:CurrentSection.Active = $true
+    $script:CurrentSection.Activity = $false
+    $script:CurrentSection.Name = $Title
     
     $purple = $script:Colors.PurpleBold
     $nc = $script:Colors.NC
@@ -146,10 +186,10 @@ function Stop-Section {
     .SYNOPSIS
         End the current section
     #>
-    if ($global:WinMoleCurrentSection.Active -and -not $global:WinMoleCurrentSection.Activity) {
+    if ($script:CurrentSection.Active -and -not $script:CurrentSection.Activity) {
         Write-Success "Nothing to tidy"
     }
-    $global:WinMoleCurrentSection.Active = $false
+    $script:CurrentSection.Active = $false
 }
 
 function Set-SectionActivity {
@@ -157,8 +197,8 @@ function Set-SectionActivity {
     .SYNOPSIS
         Mark that activity occurred in current section
     #>
-    if ($global:WinMoleCurrentSection.Active) {
-        $global:WinMoleCurrentSection.Activity = $true
+    if ($script:CurrentSection.Active) {
+        $script:CurrentSection.Activity = $true
     }
 }
 
@@ -280,4 +320,4 @@ function Disable-DebugMode {
 # ============================================================================
 # Exports (functions are available via dot-sourcing)
 # ============================================================================
-# Functions: Write-Info, Write-Success, Write-Warning, Write-Error, etc.
+# Functions: Write-Info, Write-Success, Write-WinMoleWarning, Write-WinMoleError, etc.

--- a/lib/core/ui.ps1
+++ b/lib/core/ui.ps1
@@ -180,32 +180,56 @@ function Show-Menu {
             Write-Host ""
             Write-Host "  ${gray}Use arrows or j/k to navigate, Enter to select, q to quit${nc}"
             
-            # Read key
+            # Read key - handle both VirtualKeyCode and escape sequences
             $key = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
             
-            switch ($key.VirtualKeyCode) {
-                38 { # Up arrow
-                    $selected = if ($selected -gt 0) { $selected - 1 } else { $maxIndex }
-                }
-                40 { # Down arrow
-                    $selected = if ($selected -lt $maxIndex) { $selected + 1 } else { 0 }
-                }
-                13 { # Enter
-                    # Show cursor
-                    Write-Host -NoNewline "$([char]27)[?25h"
-                    
-                    if ($AllowBack -and $selected -eq $maxIndex) {
-                        return $null  # Back selected
+            # Handle escape sequences for arrow keys (some terminals send these)
+            $moved = $false
+            if ($key.VirtualKeyCode -eq 0 -or $key.Character -eq [char]27) {
+                # Escape sequence - read the next characters
+                if ($Host.UI.RawUI.KeyAvailable) {
+                    $key2 = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+                    if ($key2.Character -eq '[' -and $Host.UI.RawUI.KeyAvailable) {
+                        $key3 = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+                        switch ($key3.Character) {
+                            'A' { # Up arrow escape sequence
+                                $selected = if ($selected -gt 0) { $selected - 1 } else { $maxIndex }
+                                $moved = $true
+                            }
+                            'B' { # Down arrow escape sequence
+                                $selected = if ($selected -lt $maxIndex) { $selected + 1 } else { 0 }
+                                $moved = $true
+                            }
+                        }
                     }
-                    return $Options[$selected]
                 }
-                default {
-                    switch ($key.Character) {
-                        'k' { $selected = if ($selected -gt 0) { $selected - 1 } else { $maxIndex } }
-                        'j' { $selected = if ($selected -lt $maxIndex) { $selected + 1 } else { 0 } }
-                        'q' { 
-                            Write-Host -NoNewline "$([char]27)[?25h"
-                            return $null 
+            }
+            
+            if (-not $moved) {
+                switch ($key.VirtualKeyCode) {
+                    38 { # Up arrow
+                        $selected = if ($selected -gt 0) { $selected - 1 } else { $maxIndex }
+                    }
+                    40 { # Down arrow
+                        $selected = if ($selected -lt $maxIndex) { $selected + 1 } else { 0 }
+                    }
+                    13 { # Enter
+                        # Show cursor
+                        Write-Host -NoNewline "$([char]27)[?25h"
+                        
+                        if ($AllowBack -and $selected -eq $maxIndex) {
+                            return $null  # Back selected
+                        }
+                        return $Options[$selected]
+                    }
+                    default {
+                        switch ($key.Character) {
+                            'k' { $selected = if ($selected -gt 0) { $selected - 1 } else { $maxIndex } }
+                            'j' { $selected = if ($selected -lt $maxIndex) { $selected + 1 } else { 0 } }
+                            'q' { 
+                                Write-Host -NoNewline "$([char]27)[?25h"
+                                return $null 
+                            }
                         }
                     }
                 }
@@ -274,42 +298,66 @@ function Show-SelectionList {
             
             $key = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
             
-            switch ($key.VirtualKeyCode) {
-                38 { $cursor = if ($cursor -gt 0) { $cursor - 1 } else { $maxIndex } }
-                40 { $cursor = if ($cursor -lt $maxIndex) { $cursor + 1 } else { 0 } }
-                32 { # Space
-                    if ($MultiSelect) {
-                        $selected[$cursor] = -not $selected[$cursor]
-                    }
-                    else {
-                        $selected = @{ $cursor = $true }
-                    }
-                }
-                13 { # Enter
-                    Write-Host -NoNewline "$([char]27)[?25h"
-                    $result = @()
-                    foreach ($key in $selected.Keys) {
-                        if ($selected[$key]) {
-                            $result += $Items[$key]
-                        }
-                    }
-                    return $result
-                }
-                default {
-                    switch ($key.Character) {
-                        'k' { $cursor = if ($cursor -gt 0) { $cursor - 1 } else { $maxIndex } }
-                        'j' { $cursor = if ($cursor -lt $maxIndex) { $cursor + 1 } else { 0 } }
-                        ' ' { 
-                            if ($MultiSelect) {
-                                $selected[$cursor] = -not $selected[$cursor]
+            # Handle escape sequences for arrow keys (some terminals send these)
+            $moved = $false
+            if ($key.VirtualKeyCode -eq 0 -or $key.Character -eq [char]27) {
+                # Escape sequence - read the next characters
+                if ($Host.UI.RawUI.KeyAvailable) {
+                    $key2 = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+                    if ($key2.Character -eq '[' -and $Host.UI.RawUI.KeyAvailable) {
+                        $key3 = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+                        switch ($key3.Character) {
+                            'A' { # Up arrow escape sequence
+                                $cursor = if ($cursor -gt 0) { $cursor - 1 } else { $maxIndex }
+                                $moved = $true
                             }
-                            else {
-                                $selected = @{ $cursor = $true }
+                            'B' { # Down arrow escape sequence
+                                $cursor = if ($cursor -lt $maxIndex) { $cursor + 1 } else { 0 }
+                                $moved = $true
                             }
                         }
-                        'q' {
-                            Write-Host -NoNewline "$([char]27)[?25h"
-                            return @()
+                    }
+                }
+            }
+            
+            if (-not $moved) {
+                switch ($key.VirtualKeyCode) {
+                    38 { $cursor = if ($cursor -gt 0) { $cursor - 1 } else { $maxIndex } }
+                    40 { $cursor = if ($cursor -lt $maxIndex) { $cursor + 1 } else { 0 } }
+                    32 { # Space
+                        if ($MultiSelect) {
+                            $selected[$cursor] = -not $selected[$cursor]
+                        }
+                        else {
+                            $selected = @{ $cursor = $true }
+                        }
+                    }
+                    13 { # Enter
+                        Write-Host -NoNewline "$([char]27)[?25h"
+                        $result = @()
+                        foreach ($selKey in $selected.Keys) {
+                            if ($selected[$selKey]) {
+                                $result += $Items[$selKey]
+                            }
+                        }
+                        return $result
+                    }
+                    default {
+                        switch ($key.Character) {
+                            'k' { $cursor = if ($cursor -gt 0) { $cursor - 1 } else { $maxIndex } }
+                            'j' { $cursor = if ($cursor -lt $maxIndex) { $cursor + 1 } else { 0 } }
+                            ' ' { 
+                                if ($MultiSelect) {
+                                    $selected[$cursor] = -not $selected[$cursor]
+                                }
+                                else {
+                                    $selected = @{ $cursor = $true }
+                                }
+                            }
+                            'q' {
+                                Write-Host -NoNewline "$([char]27)[?25h"
+                                return @()
+                            }
                         }
                     }
                 }

--- a/winmole.ps1
+++ b/winmole.ps1
@@ -155,7 +155,7 @@ function Invoke-Command {
     $scriptPath = Join-Path $script:WINMOLE_BIN "$CommandName.ps1"
     
     if (-not (Test-Path $scriptPath)) {
-        Write-Error "Unknown command: $CommandName"
+        Write-WinMoleError "Unknown command: $CommandName"
         Write-Host ""
         Write-Host "Run 'winmole -ShowHelp' for available commands"
         return
@@ -214,7 +214,7 @@ function Main {
             Invoke-Command -CommandName $Command -Arguments $CommandArgs
         }
         else {
-            Write-Error "Unknown command: $Command"
+            Write-WinMoleError "Unknown command: $Command"
             Write-Host ""
             Write-Host "Available commands: $($validCommands -join ', ')"
             Write-Host "Run 'winmole -ShowHelp' for more information"
@@ -256,7 +256,7 @@ try {
 }
 catch {
     Write-Host ""
-    Write-Error "An error occurred: $_"
+    Write-WinMoleError "An error occurred: $_"
     Write-Host ""
     exit 1
 }


### PR DESCRIPTION
## Summary

- **lib/core/log.ps1**: Add icon/color fallback defaults, rename to Write-WinMoleWarning/Write-WinMoleError, script-scoped section tracking
- **lib/core/ui.ps1**: Escape sequence handling for arrow keys, fix variable shadowing
- **All 12 files**: Rename Write-Warning -> Write-WinMoleWarning and Write-Error -> Write-WinMoleError

## Why

PS built-in Write-Warning/Write-Error conflict with function names, causing parse errors. Custom functions provide consistent WinMole UI formatting.