### PR TITLE
Add new cleanup modules: caches.ps1 and apps.ps1

### DIFF
--- a/bin/clean.ps1
+++ b/bin/clean.ps1
@@ -12,6 +12,10 @@ param(
     [switch]$System,
     [switch]$RecycleBin,
     [switch]$WindowsUpdate,
+    [switch]$Caches,
+    [switch]$GPUShaders,
+    [switch]$GameMedia,
+    [switch]$Orphaned,
     [switch]$Help
 )
 
@@ -25,6 +29,8 @@ $libDir = Join-Path (Split-Path -Parent $scriptDir) "lib"
 # Import modules
 . "$libDir\core\common.ps1"
 . "$libDir\clean\user.ps1"
+. "$libDir\clean\caches.ps1"
+. "$libDir\clean\apps.ps1"
 . "$libDir\clean\dev.ps1"
 . "$libDir\clean\system.ps1"
 
@@ -49,10 +55,14 @@ function Show-CleanHelp {
     Write-Host "    -User           Clean user caches and temp files"
     Write-Host "    -Browsers       Clean browser caches"
     Write-Host "    -Apps           Clean application caches"
+    Write-Host "    -Caches         Clean system and app caches (Store, .NET, GPU)"
+    Write-Host "    -GPUShaders     Clean GPU shader caches (NVIDIA, AMD, Intel)"
     Write-Host "    -Dev            Clean developer tool caches"
     Write-Host "    -System         Clean system caches (requires admin)"
     Write-Host "    -RecycleBin     Empty Recycle Bin"
     Write-Host "    -WindowsUpdate  Clean Windows Update cache (requires admin)"
+    Write-Host "    -GameMedia      Clean old game recordings and screenshots"
+    Write-Host "    -Orphaned       Detect and clean orphaned app data"
     Write-Host "    -Help           Show this help"
     Write-Host ""
     Write-Host "  ${gray}EXAMPLES:${nc}"
@@ -60,6 +70,8 @@ function Show-CleanHelp {
     Write-Host "    winmole clean -All               # Full cleanup"
     Write-Host "    winmole clean -User -Browsers    # User + Browser cleanup"
     Write-Host "    winmole clean -All -DryRun       # Preview all changes"
+    Write-Host "    winmole clean -Caches -GPUShaders  # Deep cache cleanup"
+    Write-Host "    winmole clean -GameMedia          # Clean old game media"
     Write-Host ""
 }
 
@@ -72,8 +84,11 @@ function Show-CleanMenu {
         @{ Name = "Quick Clean"; Description = "User caches and temp files"; Action = "quick" }
         @{ Name = "Browser Clean"; Description = "All browser caches"; Action = "browsers" }
         @{ Name = "App Clean"; Description = "Application caches"; Action = "apps" }
+        @{ Name = "Cache Clean"; Description = "System, Store, .NET, GPU shader caches"; Action = "caches" }
         @{ Name = "Developer Clean"; Description = "Dev tool caches (npm, pip, etc.)"; Action = "dev" }
         @{ Name = "System Clean"; Description = "System caches (requires admin)"; Action = "system" }
+        @{ Name = "Game Media Clean"; Description = "Old recordings, screenshots, replays"; Action = "gamemedia" }
+        @{ Name = "Orphaned Apps"; Description = "Detect leftover data from uninstalled apps"; Action = "orphaned" }
         @{ Name = "Full Clean"; Description = "Everything above"; Action = "all" }
     )
     
@@ -116,13 +131,17 @@ function Main {
     $cleanUser = $false
     $cleanBrowsers = $false
     $cleanApps = $false
+    $cleanCaches = $false
+    $cleanGPUShaders = $false
     $cleanDev = $false
     $cleanSystem = $false
     $cleanRecycleBin = $false
     $cleanWinUpdate = $false
+    $cleanGameMedia = $false
+    $cleanOrphaned = $false
     
     # If no flags specified, run interactive mode
-    $noFlags = -not ($All -or $User -or $Browsers -or $Apps -or $Dev -or $System -or $RecycleBin -or $WindowsUpdate)
+    $noFlags = -not ($All -or $User -or $Browsers -or $Apps -or $Caches -or $GPUShaders -or $Dev -or $System -or $RecycleBin -or $WindowsUpdate -or $GameMedia -or $Orphaned)
     
     if ($noFlags) {
         Clear-Host
@@ -139,15 +158,22 @@ function Main {
             "quick" { $cleanUser = $true }
             "browsers" { $cleanBrowsers = $true }
             "apps" { $cleanApps = $true }
+            "caches" { $cleanCaches = $true; $cleanGPUShaders = $true }
             "dev" { $cleanDev = $true }
             "system" { $cleanSystem = $true }
+            "gamemedia" { $cleanGameMedia = $true }
+            "orphaned" { $cleanOrphaned = $true }
             "all" { 
                 $cleanUser = $true
                 $cleanBrowsers = $true
                 $cleanApps = $true
+                $cleanCaches = $true
+                $cleanGPUShaders = $true
                 $cleanDev = $true
                 $cleanSystem = $true
                 $cleanRecycleBin = $true
+                $cleanGameMedia = $true
+                $cleanOrphaned = $true
             }
         }
         
@@ -165,19 +191,27 @@ function Main {
             $cleanUser = $true
             $cleanBrowsers = $true
             $cleanApps = $true
+            $cleanCaches = $true
+            $cleanGPUShaders = $true
             $cleanDev = $true
             $cleanSystem = $true
             $cleanRecycleBin = $true
             $cleanWinUpdate = $true
+            $cleanGameMedia = $true
+            $cleanOrphaned = $true
         }
         else {
             $cleanUser = $User
             $cleanBrowsers = $Browsers
             $cleanApps = $Apps
+            $cleanCaches = $Caches
+            $cleanGPUShaders = $GPUShaders
             $cleanDev = $Dev
             $cleanSystem = $System
             $cleanRecycleBin = $RecycleBin
             $cleanWinUpdate = $WindowsUpdate
+            $cleanGameMedia = $GameMedia
+            $cleanOrphaned = $Orphaned
         }
     }
     
@@ -198,6 +232,22 @@ function Main {
     
     if ($cleanApps) {
         Clear-ApplicationCaches
+        # Extended app cleanup: productivity, creative, gaming platform caches
+        Invoke-AppCleanup
+    }
+    
+    if ($cleanCaches) {
+        Clear-CommonAppCaches
+        Clear-StoreAppCaches
+        Clear-DotNetCaches
+        if (Test-IsAdmin) {
+            Clear-DeliveryOptimizationCache
+            Clear-FontCache
+        }
+    }
+    
+    if ($cleanGPUShaders) {
+        Clear-GPUShaderCaches
     }
     
     if ($cleanDev) {
@@ -225,6 +275,14 @@ function Main {
         else {
             Write-Warning "Windows Update cleanup requires admin - skipping"
         }
+    }
+    
+    if ($cleanGameMedia) {
+        Clear-GameMediaFiles -DaysOld 90
+    }
+    
+    if ($cleanOrphaned) {
+        Clear-OrphanedAppData -DaysOld 60
     }
     
     # Clean empty directories

--- a/lib/clean/apps.ps1
+++ b/lib/clean/apps.ps1
@@ -1,0 +1,705 @@
+# WinMole - Application-Specific Cleanup Module
+# Cleans leftover data from uninstalled apps and app-specific caches
+
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+
+# Prevent multiple sourcing
+if ((Get-Variable -Name 'WINMOLE_CLEAN_APPS_LOADED' -Scope Script -ErrorAction SilentlyContinue) -and $script:WINMOLE_CLEAN_APPS_LOADED) { return }
+$script:WINMOLE_CLEAN_APPS_LOADED = $true
+
+# Import dependencies
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$scriptDir\..\core\base.ps1"
+. "$scriptDir\..\core\log.ps1"
+. "$scriptDir\..\core\file_ops.ps1"
+
+# ============================================================================
+# Orphaned App Data Detection
+# ============================================================================
+
+function Get-InstalledPrograms {
+    <#
+    .SYNOPSIS
+        Get list of installed programs from registry
+    #>
+    
+    $programs = @()
+    
+    $registryPaths = @(
+        "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*"
+        "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+        "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    )
+    
+    foreach ($path in $registryPaths) {
+        $items = Get-ItemProperty -Path $path -ErrorAction SilentlyContinue |
+                 Where-Object { $_.DisplayName } |
+                 Select-Object DisplayName, InstallLocation, Publisher
+        if ($items) {
+            $programs += $items
+        }
+    }
+    
+    # Also check UWP apps
+    try {
+        $uwpApps = Get-AppxPackage -ErrorAction SilentlyContinue | 
+                   Select-Object @{N='DisplayName';E={$_.Name}}, @{N='InstallLocation';E={$_.InstallLocation}}, Publisher
+        if ($uwpApps) {
+            $programs += $uwpApps
+        }
+    }
+    catch {
+        Write-Debug "Could not enumerate UWP apps: $_"
+    }
+    
+    return $programs
+}
+
+function Find-OrphanedAppData {
+    <#
+    .SYNOPSIS
+        Find app data folders for apps that are no longer installed
+    #>
+    param([int]$DaysOld = 60)
+    
+    $installedPrograms = Get-InstalledPrograms
+    $installedNames = $installedPrograms | ForEach-Object { $_.DisplayName.ToLower() }
+    
+    $orphanedPaths = @()
+    $cutoffDate = (Get-Date).AddDays(-$DaysOld)
+    
+    # Check common app data locations
+    $appDataPaths = @(
+        @{ Path = $env:APPDATA; Type = "Roaming" }
+        @{ Path = $env:LOCALAPPDATA; Type = "Local" }
+    )
+    
+    foreach ($location in $appDataPaths) {
+        if (-not (Test-Path $location.Path)) { continue }
+        
+        $folders = Get-ChildItem -Path $location.Path -Directory -ErrorAction SilentlyContinue
+        
+        foreach ($folder in $folders) {
+            # Skip system folders
+            $skipFolders = @('Microsoft', 'Windows', 'Packages', 'Programs', 'Temp', 'Roaming')
+            if ($folder.Name -in $skipFolders) { continue }
+            
+            # Skip if recently modified
+            if ($folder.LastWriteTime -gt $cutoffDate) { continue }
+            
+            # Check if app is installed using stricter matching
+            $isInstalled = $false
+            $folderLower = $folder.Name.ToLower()
+            foreach ($name in $installedNames) {
+                # Exact match
+                if ($name -eq $folderLower) {
+                    $isInstalled = $true
+                    break
+                }
+                # Folder is prefix of app name (e.g., "chrome" matches "chrome browser")
+                if ($name.StartsWith($folderLower) -and $folderLower.Length -ge 4) {
+                    $isInstalled = $true
+                    break
+                }
+                # App name is prefix of folder (e.g., "vscode" matches "vscode-data")
+                if ($folderLower.StartsWith($name) -and $name.Length -ge 4) {
+                    $isInstalled = $true
+                    break
+                }
+            }
+            
+            if (-not $isInstalled) {
+                $orphanedPaths += @{
+                    Path = $folder.FullName
+                    Name = $folder.Name
+                    Type = $location.Type
+                    Size = (Get-PathSize -Path $folder.FullName)
+                    LastModified = $folder.LastWriteTime
+                }
+            }
+        }
+    }
+    
+    return $orphanedPaths
+}
+
+function Clear-OrphanedAppData {
+    <#
+    .SYNOPSIS
+        Clean orphaned application data
+    #>
+    param([int]$DaysOld = 60)
+    
+    Start-Section "Orphaned app data"
+    
+    $orphaned = Find-OrphanedAppData -DaysOld $DaysOld
+    
+    if ($orphaned.Count -eq 0) {
+        Write-Info "No orphaned app data found"
+        Stop-Section
+        return
+    }
+    
+    # Filter by size (only clean if > 10MB to avoid noise)
+    $significantOrphans = $orphaned | Where-Object { $_.Size -gt 10MB }
+    
+    if ($significantOrphans.Count -gt 0) {
+        $totalSize = ($significantOrphans | Measure-Object -Property Size -Sum).Sum
+        $sizeHuman = Format-ByteSize -Bytes $totalSize
+        
+        Write-Info "Found $($significantOrphans.Count) orphaned folders ($sizeHuman)"
+        
+        foreach ($orphan in $significantOrphans) {
+            $orphanSize = Format-ByteSize -Bytes $orphan.Size
+            Remove-SafeItem -Path $orphan.Path -Description "$($orphan.Name) ($orphanSize)" -Recurse
+        }
+    }
+    
+    Stop-Section
+}
+
+# ============================================================================
+# Specific Application Cleanup
+# ============================================================================
+
+function Clear-OfficeCache {
+    <#
+    .SYNOPSIS
+        Clean Microsoft Office caches and temp files
+    #>
+    
+    $officeCachePaths = @(
+        # Office 365 / 2019 / 2021
+        "$env:LOCALAPPDATA\Microsoft\Office\16.0\OfficeFileCache"
+        "$env:LOCALAPPDATA\Microsoft\Office\16.0\Wef"
+        "$env:LOCALAPPDATA\Microsoft\Outlook\RoamCache"
+        "$env:LOCALAPPDATA\Microsoft\Outlook\Offline Address Books"
+        # Older Office versions
+        "$env:LOCALAPPDATA\Microsoft\Office\15.0\OfficeFileCache"
+        # Office temp files
+        "$env:APPDATA\Microsoft\Templates\*.tmp"
+        "$env:APPDATA\Microsoft\Word\*.tmp"
+        "$env:APPDATA\Microsoft\Excel\*.tmp"
+        "$env:APPDATA\Microsoft\PowerPoint\*.tmp"
+    )
+    
+    foreach ($path in $officeCachePaths) {
+        if ($path -like "*.tmp") {
+            $parent = Split-Path -Parent $path
+            if (Test-Path $parent) {
+                $tmpFiles = Get-ChildItem -Path $parent -Filter "*.tmp" -File -ErrorAction SilentlyContinue
+                if ($tmpFiles) {
+                    $paths = $tmpFiles | ForEach-Object { $_.FullName }
+                    Remove-SafeItems -Paths $paths -Description "Office temp files"
+                }
+            }
+        }
+        elseif (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Office $(Split-Path -Leaf $path)"
+        }
+    }
+}
+
+function Clear-OneDriveCache {
+    <#
+    .SYNOPSIS
+        Clean OneDrive cache
+    #>
+    
+    $oneDriveCachePaths = @(
+        "$env:LOCALAPPDATA\Microsoft\OneDrive\logs"
+        "$env:LOCALAPPDATA\Microsoft\OneDrive\setup\logs"
+    )
+    
+    foreach ($path in $oneDriveCachePaths) {
+        if (Test-Path $path) {
+            Remove-OldFiles -Path $path -DaysOld 7 -Description "OneDrive logs"
+        }
+    }
+}
+
+function Clear-DropboxCache {
+    <#
+    .SYNOPSIS
+        Clean Dropbox cache
+    #>
+    
+    # Dropbox cache is typically in the Dropbox folder itself
+    $dropboxInfoPath = "$env:LOCALAPPDATA\Dropbox\info.json"
+    
+    if (Test-Path $dropboxInfoPath) {
+        try {
+            $dropboxInfo = Get-Content $dropboxInfoPath | ConvertFrom-Json
+            $dropboxPath = $dropboxInfo.personal.path
+            
+            if ($dropboxPath) {
+                $dropboxCachePath = "$dropboxPath\.dropbox.cache"
+                if (Test-Path $dropboxCachePath) {
+                    Clear-DirectoryContents -Path $dropboxCachePath -Description "Dropbox cache"
+                }
+            }
+        }
+        catch {
+            Write-Debug "Could not read Dropbox config: $_"
+        }
+    }
+}
+
+function Clear-GoogleDriveCache {
+    <#
+    .SYNOPSIS
+        Clean Google Drive cache
+    #>
+    
+    $googleDriveCachePaths = @(
+        "$env:LOCALAPPDATA\Google\DriveFS\Logs"
+        "$env:LOCALAPPDATA\Google\DriveFS\*.tmp"
+    )
+    
+    foreach ($path in $googleDriveCachePaths) {
+        if ($path -like "*.tmp") {
+            $parent = Split-Path -Parent $path
+            if (Test-Path $parent) {
+                $tmpFiles = Get-ChildItem -Path $parent -Filter "*.tmp" -ErrorAction SilentlyContinue
+                if ($tmpFiles) {
+                    $paths = $tmpFiles | ForEach-Object { $_.FullName }
+                    Remove-SafeItems -Paths $paths -Description "Google Drive temp"
+                }
+            }
+        }
+        elseif (Test-Path $path) {
+            Remove-OldFiles -Path $path -DaysOld 7 -Description "Google Drive logs"
+        }
+    }
+}
+
+function Clear-AdobeData {
+    <#
+    .SYNOPSIS
+        Clean Adobe application caches and temp files
+    #>
+    
+    $adobeCachePaths = @(
+        "$env:APPDATA\Adobe\Common\Media Cache Files"
+        "$env:APPDATA\Adobe\Common\Peak Files"
+        "$env:APPDATA\Adobe\Common\Team Projects Cache"
+        "$env:LOCALAPPDATA\Adobe\*\Cache"
+        "$env:LOCALAPPDATA\Adobe\*\CameraRaw\Cache"
+        "$env:LOCALAPPDATA\Temp\Adobe"
+    )
+    
+    foreach ($pattern in $adobeCachePaths) {
+        $paths = Resolve-Path $pattern -ErrorAction SilentlyContinue
+        foreach ($path in $paths) {
+            if (Test-Path $path.Path) {
+                Clear-DirectoryContents -Path $path.Path -Description "Adobe cache"
+            }
+        }
+    }
+}
+
+function Clear-AutodeskData {
+    <#
+    .SYNOPSIS
+        Clean Autodesk application caches
+    #>
+    
+    $autodeskCachePaths = @(
+        "$env:LOCALAPPDATA\Autodesk\*\Cache"
+        "$env:APPDATA\Autodesk\*\cache"
+    )
+    
+    foreach ($pattern in $autodeskCachePaths) {
+        $paths = Resolve-Path $pattern -ErrorAction SilentlyContinue
+        foreach ($path in $paths) {
+            if (Test-Path $path.Path) {
+                Clear-DirectoryContents -Path $path.Path -Description "Autodesk cache"
+            }
+        }
+    }
+}
+
+# ============================================================================
+# Gaming Platform Cleanup
+# ============================================================================
+
+function Clear-GamingPlatformCaches {
+    <#
+    .SYNOPSIS
+        Clean gaming platform caches (Steam, Epic, Origin, etc.)
+    #>
+    
+    # Steam
+    $steamPaths = @(
+        "${env:ProgramFiles(x86)}\Steam\appcache\httpcache"
+        "${env:ProgramFiles(x86)}\Steam\appcache\librarycache"
+        "${env:ProgramFiles(x86)}\Steam\logs"
+    )
+    foreach ($path in $steamPaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Steam $(Split-Path -Leaf $path)"
+        }
+    }
+    
+    # Epic Games Launcher
+    $epicPaths = @(
+        "$env:LOCALAPPDATA\EpicGamesLauncher\Saved\webcache"
+        "$env:LOCALAPPDATA\EpicGamesLauncher\Saved\Logs"
+    )
+    foreach ($path in $epicPaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Epic Games $(Split-Path -Leaf $path)"
+        }
+    }
+    
+    # EA App (Origin replacement)
+    $eaPaths = @(
+        "$env:LOCALAPPDATA\Electronic Arts\EA Desktop\cache"
+        "$env:APPDATA\Origin\*\cache"
+    )
+    foreach ($pattern in $eaPaths) {
+        $paths = Resolve-Path $pattern -ErrorAction SilentlyContinue
+        foreach ($path in $paths) {
+            if (Test-Path $path.Path) {
+                Clear-DirectoryContents -Path $path.Path -Description "EA/Origin cache"
+            }
+        }
+    }
+    
+    # GOG Galaxy
+    $gogPaths = @(
+        "$env:LOCALAPPDATA\GOG.com\Galaxy\webcache"
+        "$env:PROGRAMDATA\GOG.com\Galaxy\logs"
+    )
+    foreach ($path in $gogPaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "GOG Galaxy $(Split-Path -Leaf $path)"
+        }
+    }
+    
+    # Ubisoft Connect
+    $ubiPaths = @(
+        "$env:LOCALAPPDATA\Ubisoft Game Launcher\cache"
+        "$env:LOCALAPPDATA\Ubisoft Game Launcher\logs"
+    )
+    foreach ($path in $ubiPaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Ubisoft $(Split-Path -Leaf $path)"
+        }
+    }
+    
+    # Battle.net
+    $battlenetPaths = @(
+        "$env:APPDATA\Battle.net\Cache"
+        "$env:APPDATA\Battle.net\Logs"
+    )
+    foreach ($path in $battlenetPaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Battle.net $(Split-Path -Leaf $path)"
+        }
+    }
+}
+
+# ============================================================================
+# Game Media Cleanup (Replays, Screenshots, Recordings)
+# ============================================================================
+
+function Clear-GameMediaFiles {
+    <#
+    .SYNOPSIS
+        Clean old game replays, screenshots, and recordings
+    .DESCRIPTION
+        Removes old media files from various gaming sources:
+        - NVIDIA ShadowPlay/Highlights
+        - AMD ReLive
+        - Xbox Game Bar captures
+        - Steam screenshots
+        - OBS recordings
+        - Windows Game DVR
+        
+        By default, only removes files older than 90 days.
+        User media in standard Pictures/Videos folders is NOT touched
+        unless it's in a game-specific subfolder.
+    .PARAMETER DaysOld
+        Minimum age of files to remove (default: 90 days)
+    #>
+    param(
+        [int]$DaysOld = 90
+    )
+    
+    Start-Section "Game media (>${DaysOld}d old)"
+    
+    $cutoffDate = (Get-Date).AddDays(-$DaysOld)
+    $mediaExtensions = @('*.mp4', '*.mkv', '*.avi', '*.mov', '*.wmv', '*.webm', '*.png', '*.jpg', '*.jpeg', '*.bmp', '*.gif')
+    
+    # -------------------------------------------------------------------------
+    # NVIDIA ShadowPlay / GeForce Experience
+    # -------------------------------------------------------------------------
+    $nvidiaPaths = @(
+        "$env:USERPROFILE\Videos\NVIDIA"
+        "$env:USERPROFILE\Videos\ShadowPlay"
+        "$env:USERPROFILE\Videos\GeForce Experience"
+    )
+    
+    foreach ($basePath in $nvidiaPaths) {
+        if (Test-Path $basePath) {
+            foreach ($ext in $mediaExtensions) {
+                $oldFiles = Get-ChildItem -Path $basePath -Filter $ext -File -Recurse -ErrorAction SilentlyContinue |
+                            Where-Object { $_.LastWriteTime -lt $cutoffDate }
+                if ($oldFiles) {
+                    $paths = $oldFiles | ForEach-Object { $_.FullName }
+                    Remove-SafeItems -Paths $paths -Description "NVIDIA recordings (>${DaysOld}d)"
+                }
+            }
+        }
+    }
+    
+    # NVIDIA Highlights (game-specific clips)
+    $highlightsPath = "$env:USERPROFILE\Videos\NVIDIA\Highlights"
+    if (Test-Path $highlightsPath) {
+        $oldHighlights = Get-ChildItem -Path $highlightsPath -File -Recurse -ErrorAction SilentlyContinue |
+                         Where-Object { $_.LastWriteTime -lt $cutoffDate -and $_.Extension -match '\.(mp4|mkv|avi|mov)$' }
+        if ($oldHighlights) {
+            $paths = $oldHighlights | ForEach-Object { $_.FullName }
+            Remove-SafeItems -Paths $paths -Description "NVIDIA Highlights (>${DaysOld}d)"
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # AMD ReLive / Radeon Software
+    # -------------------------------------------------------------------------
+    $amdPaths = @(
+        "$env:USERPROFILE\Videos\Radeon ReLive"
+        "$env:USERPROFILE\Videos\AMD"
+        "$env:USERPROFILE\Videos\Radeon"
+    )
+    
+    foreach ($basePath in $amdPaths) {
+        if (Test-Path $basePath) {
+            foreach ($ext in $mediaExtensions) {
+                $oldFiles = Get-ChildItem -Path $basePath -Filter $ext -File -Recurse -ErrorAction SilentlyContinue |
+                            Where-Object { $_.LastWriteTime -lt $cutoffDate }
+                if ($oldFiles) {
+                    $paths = $oldFiles | ForEach-Object { $_.FullName }
+                    Remove-SafeItems -Paths $paths -Description "AMD ReLive recordings (>${DaysOld}d)"
+                }
+            }
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # Xbox Game Bar / Windows Game DVR
+    # -------------------------------------------------------------------------
+    $xboxCapturesPath = "$env:USERPROFILE\Videos\Captures"
+    if (Test-Path $xboxCapturesPath) {
+        foreach ($ext in $mediaExtensions) {
+            $oldFiles = Get-ChildItem -Path $xboxCapturesPath -Filter $ext -File -ErrorAction SilentlyContinue |
+                        Where-Object { $_.LastWriteTime -lt $cutoffDate }
+            if ($oldFiles) {
+                $paths = $oldFiles | ForEach-Object { $_.FullName }
+                Remove-SafeItems -Paths $paths -Description "Xbox Game Bar captures (>${DaysOld}d)"
+            }
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # Windows Snipping Tool / Snip & Sketch Screenshots
+    # -------------------------------------------------------------------------
+    $windowsScreenshotsPath = "$env:USERPROFILE\Pictures\Screenshots"
+    if (Test-Path $windowsScreenshotsPath) {
+        foreach ($ext in @('*.png', '*.jpg', '*.jpeg', '*.gif', '*.bmp')) {
+            $oldFiles = Get-ChildItem -Path $windowsScreenshotsPath -Filter $ext -File -ErrorAction SilentlyContinue |
+                        Where-Object { $_.LastWriteTime -lt $cutoffDate }
+            if ($oldFiles) {
+                $paths = $oldFiles | ForEach-Object { $_.FullName }
+                Remove-SafeItems -Paths $paths -Description "Windows screenshots (>${DaysOld}d)"
+            }
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # Windows Screen Recordings (Snipping Tool / Win+Alt+R)
+    # -------------------------------------------------------------------------
+    $windowsRecordingsPath = "$env:USERPROFILE\Videos\Screen Recordings"
+    if (Test-Path $windowsRecordingsPath) {
+        foreach ($ext in @('*.mp4', '*.mkv', '*.avi', '*.mov', '*.wmv')) {
+            $oldFiles = Get-ChildItem -Path $windowsRecordingsPath -Filter $ext -File -ErrorAction SilentlyContinue |
+                        Where-Object { $_.LastWriteTime -lt $cutoffDate }
+            if ($oldFiles) {
+                $paths = $oldFiles | ForEach-Object { $_.FullName }
+                Remove-SafeItems -Paths $paths -Description "Windows screen recordings (>${DaysOld}d)"
+            }
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # Steam Screenshots
+    # -------------------------------------------------------------------------
+    $steamUserDataPath = "${env:ProgramFiles(x86)}\Steam\userdata"
+    if (Test-Path $steamUserDataPath) {
+        $screenshotFolders = Get-ChildItem -Path $steamUserDataPath -Directory -ErrorAction SilentlyContinue |
+                             ForEach-Object { Join-Path $_.FullName "760\remote" } |
+                             Where-Object { Test-Path $_ }
+        
+        foreach ($folder in $screenshotFolders) {
+            $oldScreenshots = Get-ChildItem -Path $folder -Filter "*.jpg" -File -Recurse -ErrorAction SilentlyContinue |
+                              Where-Object { $_.LastWriteTime -lt $cutoffDate }
+            if ($oldScreenshots) {
+                $paths = $oldScreenshots | ForEach-Object { $_.FullName }
+                Remove-SafeItems -Paths $paths -Description "Steam screenshots (>${DaysOld}d)"
+            }
+        }
+    }
+    
+    # Also check common Steam screenshot export location
+    $steamScreenshotsPath = "$env:USERPROFILE\Pictures\Steam Screenshots"
+    if (Test-Path $steamScreenshotsPath) {
+        $oldFiles = Get-ChildItem -Path $steamScreenshotsPath -Filter "*.jpg" -File -Recurse -ErrorAction SilentlyContinue |
+                    Where-Object { $_.LastWriteTime -lt $cutoffDate }
+        if ($oldFiles) {
+            $paths = $oldFiles | ForEach-Object { $_.FullName }
+            Remove-SafeItems -Paths $paths -Description "Steam exported screenshots (>${DaysOld}d)"
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # OBS Studio Recordings
+    # -------------------------------------------------------------------------
+    $obsRecordingsPath = "$env:USERPROFILE\Videos\OBS"
+    if (Test-Path $obsRecordingsPath) {
+        foreach ($ext in @('*.mp4', '*.mkv', '*.flv', '*.mov', '*.ts')) {
+            $oldFiles = Get-ChildItem -Path $obsRecordingsPath -Filter $ext -File -Recurse -ErrorAction SilentlyContinue |
+                        Where-Object { $_.LastWriteTime -lt $cutoffDate }
+            if ($oldFiles) {
+                $paths = $oldFiles | ForEach-Object { $_.FullName }
+                Remove-SafeItems -Paths $paths -Description "OBS recordings (>${DaysOld}d)"
+            }
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # Windows Game DVR (legacy location)
+    # -------------------------------------------------------------------------
+    $gameDvrPath = "$env:LOCALAPPDATA\Packages\Microsoft.XboxGamingOverlay_*\LocalState\GameDVR"
+    $gameDvrPaths = Resolve-Path $gameDvrPath -ErrorAction SilentlyContinue
+    foreach ($path in $gameDvrPaths) {
+        if (Test-Path $path.Path) {
+            $oldFiles = Get-ChildItem -Path $path.Path -File -Recurse -ErrorAction SilentlyContinue |
+                        Where-Object { $_.LastWriteTime -lt $cutoffDate -and $_.Extension -match '\.(mp4|png)$' }
+            if ($oldFiles) {
+                $paths = $oldFiles | ForEach-Object { $_.FullName }
+                Remove-SafeItems -Paths $paths -Description "Game DVR recordings (>${DaysOld}d)"
+            }
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # Medal.tv Clips
+    # -------------------------------------------------------------------------
+    $medalPath = "$env:USERPROFILE\Videos\Medal"
+    if (Test-Path $medalPath) {
+        foreach ($ext in $mediaExtensions) {
+            $oldFiles = Get-ChildItem -Path $medalPath -Filter $ext -File -Recurse -ErrorAction SilentlyContinue |
+                        Where-Object { $_.LastWriteTime -lt $cutoffDate }
+            if ($oldFiles) {
+                $paths = $oldFiles | ForEach-Object { $_.FullName }
+                Remove-SafeItems -Paths $paths -Description "Medal.tv clips (>${DaysOld}d)"
+            }
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # Overwolf / Outplayed Recordings
+    # -------------------------------------------------------------------------
+    $overwolfPaths = @(
+        "$env:USERPROFILE\Videos\Overwolf"
+        "$env:USERPROFILE\Videos\Outplayed"
+    )
+    foreach ($basePath in $overwolfPaths) {
+        if (Test-Path $basePath) {
+            foreach ($ext in $mediaExtensions) {
+                $oldFiles = Get-ChildItem -Path $basePath -Filter $ext -File -Recurse -ErrorAction SilentlyContinue |
+                            Where-Object { $_.LastWriteTime -lt $cutoffDate }
+                if ($oldFiles) {
+                    $paths = $oldFiles | ForEach-Object { $_.FullName }
+                    Remove-SafeItems -Paths $paths -Description "Overwolf/Outplayed recordings (>${DaysOld}d)"
+                }
+            }
+        }
+    }
+    
+    # -------------------------------------------------------------------------
+    # Game-specific replay folders (common locations)
+    # -------------------------------------------------------------------------
+    $gameReplayPaths = @(
+        "$env:LOCALAPPDATA\FortniteGame\Saved\Demos"
+        "$env:USERPROFILE\Documents\League of Legends\Replays"
+        "$env:LOCALAPPDATA\VALORANT\Saved\Logs"
+        "$env:USERPROFILE\Documents\My Games\Rocket League\TAGame\Demos"
+        "$env:USERPROFILE\Documents\Call of Duty\players\theatre"
+        "$env:USERPROFILE\Saved Games\Respawn\Apex\assets\temp"
+    )
+    
+    foreach ($path in $gameReplayPaths) {
+        if (Test-Path $path) {
+            $oldFiles = Get-ChildItem -Path $path -File -Recurse -ErrorAction SilentlyContinue |
+                        Where-Object { $_.LastWriteTime -lt $cutoffDate }
+            if ($oldFiles) {
+                $gameName = (Split-Path (Split-Path $path -Parent) -Leaf)
+                $paths = $oldFiles | ForEach-Object { $_.FullName }
+                Remove-SafeItems -Paths $paths -Description "$gameName replays (>${DaysOld}d)"
+            }
+        }
+    }
+    
+    Stop-Section
+}
+
+# ============================================================================
+# Main Application Cleanup Function
+# ============================================================================
+
+function Invoke-AppCleanup {
+    <#
+    .SYNOPSIS
+        Run all application-specific cleanup tasks
+    #>
+    param(
+        [switch]$IncludeOrphaned,
+        [switch]$IncludeGameMedia,
+        [int]$GameMediaDaysOld = 90
+    )
+    
+    Start-Section "Applications"
+    
+    # Productivity apps
+    Clear-OfficeCache
+    Clear-OneDriveCache
+    Clear-DropboxCache
+    Clear-GoogleDriveCache
+    
+    # Creative apps
+    Clear-AdobeData
+    Clear-AutodeskData
+    
+    # Gaming platforms
+    Clear-GamingPlatformCaches
+    
+    Stop-Section
+    
+    # Game media (replays, screenshots, recordings)
+    if ($IncludeGameMedia) {
+        Clear-GameMediaFiles -DaysOld $GameMediaDaysOld
+    }
+    
+    # Orphaned app data (separate section)
+    if ($IncludeOrphaned) {
+        Clear-OrphanedAppData -DaysOld 60
+    }
+}
+
+# ============================================================================
+# Exports
+# ============================================================================
+# Functions: Get-InstalledPrograms, Find-OrphanedAppData, Clear-OfficeCache, etc.

--- a/lib/clean/apps.ps1
+++ b/lib/clean/apps.ps1
@@ -81,8 +81,13 @@ function Find-OrphanedAppData {
         $folders = Get-ChildItem -Path $location.Path -Directory -ErrorAction SilentlyContinue
         
         foreach ($folder in $folders) {
-            # Skip system folders
-            $skipFolders = @('Microsoft', 'Windows', 'Packages', 'Programs', 'Temp', 'Roaming')
+            # Skip system and framework folders that persist independently of app installations
+            $skipFolders = @(
+                'Microsoft', 'Windows', 'Packages', 'Programs', 'Temp', 'Roaming',
+                'Local', 'LocalLow', 'VirtualStore',  # System directories
+                'Google', 'Mozilla', 'Adobe',          # Framework/updater folders
+                'Intel', 'NVIDIA', 'AMD', 'Realtek'    # Hardware driver folders
+            )
             if ($folder.Name -in $skipFolders) { continue }
             
             # Skip if recently modified
@@ -499,36 +504,6 @@ function Clear-GameMediaFiles {
             if ($oldFiles) {
                 $paths = $oldFiles | ForEach-Object { $_.FullName }
                 Remove-SafeItems -Paths $paths -Description "Xbox Game Bar captures (>${DaysOld}d)"
-            }
-        }
-    }
-    
-    # -------------------------------------------------------------------------
-    # Windows Snipping Tool / Snip & Sketch Screenshots
-    # -------------------------------------------------------------------------
-    $windowsScreenshotsPath = "$env:USERPROFILE\Pictures\Screenshots"
-    if (Test-Path $windowsScreenshotsPath) {
-        foreach ($ext in @('*.png', '*.jpg', '*.jpeg', '*.gif', '*.bmp')) {
-            $oldFiles = Get-ChildItem -Path $windowsScreenshotsPath -Filter $ext -File -ErrorAction SilentlyContinue |
-                        Where-Object { $_.LastWriteTime -lt $cutoffDate }
-            if ($oldFiles) {
-                $paths = $oldFiles | ForEach-Object { $_.FullName }
-                Remove-SafeItems -Paths $paths -Description "Windows screenshots (>${DaysOld}d)"
-            }
-        }
-    }
-    
-    # -------------------------------------------------------------------------
-    # Windows Screen Recordings (Snipping Tool / Win+Alt+R)
-    # -------------------------------------------------------------------------
-    $windowsRecordingsPath = "$env:USERPROFILE\Videos\Screen Recordings"
-    if (Test-Path $windowsRecordingsPath) {
-        foreach ($ext in @('*.mp4', '*.mkv', '*.avi', '*.mov', '*.wmv')) {
-            $oldFiles = Get-ChildItem -Path $windowsRecordingsPath -Filter $ext -File -ErrorAction SilentlyContinue |
-                        Where-Object { $_.LastWriteTime -lt $cutoffDate }
-            if ($oldFiles) {
-                $paths = $oldFiles | ForEach-Object { $_.FullName }
-                Remove-SafeItems -Paths $paths -Description "Windows screen recordings (>${DaysOld}d)"
             }
         }
     }

--- a/lib/clean/caches.ps1
+++ b/lib/clean/caches.ps1
@@ -39,14 +39,22 @@ function Clear-WindowsUpdateDownloads {
             return
         }
         
+        $wuService = Get-Service -Name wuauserv -ErrorAction SilentlyContinue
+        $wasRunning = $wuService -and $wuService.Status -eq 'Running'
+        
         try {
-            Stop-Service -Name wuauserv -Force -ErrorAction SilentlyContinue
+            if ($wasRunning) {
+                Stop-Service -Name wuauserv -Force -ErrorAction SilentlyContinue
+            }
             Clear-DirectoryContents -Path $wuPath -Description "Windows Update cache"
-            Start-Service -Name wuauserv -ErrorAction SilentlyContinue
         }
         catch {
             Write-Debug "Could not clear Windows Update cache: $_"
-            Start-Service -Name wuauserv -ErrorAction SilentlyContinue
+        }
+        finally {
+            if ($wasRunning) {
+                Start-Service -Name wuauserv -ErrorAction SilentlyContinue
+            }
         }
     }
 }
@@ -71,14 +79,22 @@ function Clear-DeliveryOptimizationCache {
             return
         }
         
+        $doService = Get-Service -Name DoSvc -ErrorAction SilentlyContinue
+        $wasRunning = $doService -and $doService.Status -eq 'Running'
+        
         try {
-            Stop-Service -Name DoSvc -Force -ErrorAction SilentlyContinue
+            if ($wasRunning) {
+                Stop-Service -Name DoSvc -Force -ErrorAction SilentlyContinue
+            }
             Clear-DirectoryContents -Path "$doPath\Cache" -Description "Delivery Optimization cache"
-            Start-Service -Name DoSvc -ErrorAction SilentlyContinue
         }
         catch {
             Write-Debug "Could not clear Delivery Optimization cache: $_"
-            Start-Service -Name DoSvc -ErrorAction SilentlyContinue
+        }
+        finally {
+            if ($wasRunning) {
+                Start-Service -Name DoSvc -ErrorAction SilentlyContinue
+            }
         }
     }
 }

--- a/lib/clean/caches.ps1
+++ b/lib/clean/caches.ps1
@@ -1,0 +1,466 @@
+# WinMole - Cache Cleanup Module
+# Cleans Windows and application caches
+
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+
+# Prevent multiple sourcing
+if ((Get-Variable -Name 'WINMOLE_CLEAN_CACHES_LOADED' -Scope Script -ErrorAction SilentlyContinue) -and $script:WINMOLE_CLEAN_CACHES_LOADED) { return }
+$script:WINMOLE_CLEAN_CACHES_LOADED = $true
+
+# Import dependencies
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+. "$scriptDir\..\core\base.ps1"
+. "$scriptDir\..\core\log.ps1"
+. "$scriptDir\..\core\file_ops.ps1"
+
+# ============================================================================
+# Windows System Caches
+# ============================================================================
+
+function Clear-WindowsUpdateDownloads {
+    <#
+    .SYNOPSIS
+        Clean Windows Update download cache (requires admin)
+    #>
+    
+    if (-not (Test-IsAdmin)) {
+        Write-Debug "Skipping Windows Update cache - requires admin"
+        return
+    }
+    
+    $wuPath = "$env:WINDIR\SoftwareDistribution\Download"
+    
+    if (Test-Path $wuPath) {
+        # Stop Windows Update service first
+        if (Test-DryRunMode) {
+            Write-DryRun "Windows Update cache"
+            Set-SectionActivity
+            return
+        }
+        
+        try {
+            Stop-Service -Name wuauserv -Force -ErrorAction SilentlyContinue
+            Clear-DirectoryContents -Path $wuPath -Description "Windows Update cache"
+            Start-Service -Name wuauserv -ErrorAction SilentlyContinue
+        }
+        catch {
+            Write-Debug "Could not clear Windows Update cache: $_"
+            Start-Service -Name wuauserv -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Clear-DeliveryOptimizationCache {
+    <#
+    .SYNOPSIS
+        Clean Windows Delivery Optimization cache (requires admin)
+    #>
+    
+    if (-not (Test-IsAdmin)) {
+        Write-Debug "Skipping Delivery Optimization cache - requires admin"
+        return
+    }
+    
+    $doPath = "$env:WINDIR\ServiceProfiles\NetworkService\AppData\Local\Microsoft\Windows\DeliveryOptimization"
+    
+    if (Test-Path $doPath) {
+        if (Test-DryRunMode) {
+            Write-DryRun "Delivery Optimization cache"
+            Set-SectionActivity
+            return
+        }
+        
+        try {
+            Stop-Service -Name DoSvc -Force -ErrorAction SilentlyContinue
+            Clear-DirectoryContents -Path "$doPath\Cache" -Description "Delivery Optimization cache"
+            Start-Service -Name DoSvc -ErrorAction SilentlyContinue
+        }
+        catch {
+            Write-Debug "Could not clear Delivery Optimization cache: $_"
+            Start-Service -Name DoSvc -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Clear-FontCache {
+    <#
+    .SYNOPSIS
+        Clean Windows font cache (requires admin)
+    #>
+    
+    if (-not (Test-IsAdmin)) {
+        return
+    }
+    
+    $fontCachePath = "$env:LOCALAPPDATA\Microsoft\Windows\Fonts\FontCache"
+    
+    if (Test-Path $fontCachePath) {
+        Remove-SafeItem -Path $fontCachePath -Description "Font cache"
+    }
+}
+
+# ============================================================================
+# Browser Caches
+# ============================================================================
+
+function Clear-BrowserCacheFiles {
+    <#
+    .SYNOPSIS
+        Clean browser cache directories
+    #>
+    
+    Start-Section "Browser caches"
+    
+    # Chrome
+    $chromeCachePaths = @(
+        "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Cache"
+        "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Code Cache"
+        "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\GPUCache"
+        "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Service Worker\CacheStorage"
+        "$env:LOCALAPPDATA\Google\Chrome\User Data\ShaderCache"
+        "$env:LOCALAPPDATA\Google\Chrome\User Data\GrShaderCache"
+    )
+    
+    foreach ($path in $chromeCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Chrome $(Split-Path -Leaf $path)"
+        }
+    }
+    
+    # Edge
+    $edgeCachePaths = @(
+        "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Cache"
+        "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Code Cache"
+        "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\GPUCache"
+        "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Service Worker\CacheStorage"
+        "$env:LOCALAPPDATA\Microsoft\Edge\User Data\ShaderCache"
+    )
+    
+    foreach ($path in $edgeCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Edge $(Split-Path -Leaf $path)"
+        }
+    }
+    
+    # Firefox
+    $firefoxProfiles = "$env:APPDATA\Mozilla\Firefox\Profiles"
+    if (Test-Path $firefoxProfiles) {
+        $profiles = Get-ChildItem -Path $firefoxProfiles -Directory -ErrorAction SilentlyContinue
+        foreach ($profile in $profiles) {
+            $firefoxCachePaths = @(
+                "$($profile.FullName)\cache2"
+                "$($profile.FullName)\startupCache"
+                "$($profile.FullName)\shader-cache"
+            )
+            foreach ($path in $firefoxCachePaths) {
+                if (Test-Path $path) {
+                    Clear-DirectoryContents -Path $path -Description "Firefox cache"
+                }
+            }
+        }
+    }
+    
+    # Brave
+    $braveCachePath = "$env:LOCALAPPDATA\BraveSoftware\Brave-Browser\User Data\Default\Cache"
+    if (Test-Path $braveCachePath) {
+        Clear-DirectoryContents -Path $braveCachePath -Description "Brave cache"
+    }
+    
+    # Opera
+    $operaCachePath = "$env:APPDATA\Opera Software\Opera Stable\Cache"
+    if (Test-Path $operaCachePath) {
+        Clear-DirectoryContents -Path $operaCachePath -Description "Opera cache"
+    }
+    
+    Stop-Section
+}
+
+# ============================================================================
+# Application Caches
+# ============================================================================
+
+function Clear-CommonAppCaches {
+    <#
+    .SYNOPSIS
+        Clean common application caches
+    #>
+    
+    Start-Section "Application caches"
+    
+    # Spotify
+    $spotifyCachePaths = @(
+        "$env:LOCALAPPDATA\Spotify\Data"
+        "$env:LOCALAPPDATA\Spotify\Storage"
+    )
+    foreach ($path in $spotifyCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Spotify cache"
+        }
+    }
+    
+    # Discord
+    $discordCachePaths = @(
+        "$env:APPDATA\discord\Cache"
+        "$env:APPDATA\discord\Code Cache"
+        "$env:APPDATA\discord\GPUCache"
+    )
+    foreach ($path in $discordCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Discord cache"
+        }
+    }
+    
+    # Slack
+    $slackCachePaths = @(
+        "$env:APPDATA\Slack\Cache"
+        "$env:APPDATA\Slack\Code Cache"
+        "$env:APPDATA\Slack\GPUCache"
+        "$env:APPDATA\Slack\Service Worker\CacheStorage"
+    )
+    foreach ($path in $slackCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Slack cache"
+        }
+    }
+    
+    # Teams
+    $teamsCachePaths = @(
+        "$env:APPDATA\Microsoft\Teams\Cache"
+        "$env:APPDATA\Microsoft\Teams\blob_storage"
+        "$env:APPDATA\Microsoft\Teams\databases"
+        "$env:APPDATA\Microsoft\Teams\GPUCache"
+        "$env:APPDATA\Microsoft\Teams\IndexedDB"
+        "$env:APPDATA\Microsoft\Teams\Local Storage"
+        "$env:APPDATA\Microsoft\Teams\tmp"
+    )
+    foreach ($path in $teamsCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Teams cache"
+        }
+    }
+    
+    # VS Code
+    $vscodeCachePaths = @(
+        "$env:APPDATA\Code\Cache"
+        "$env:APPDATA\Code\CachedData"
+        "$env:APPDATA\Code\CachedExtensions"
+        "$env:APPDATA\Code\CachedExtensionVSIXs"
+        "$env:APPDATA\Code\Code Cache"
+        "$env:APPDATA\Code\GPUCache"
+    )
+    foreach ($path in $vscodeCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "VS Code cache"
+        }
+    }
+    
+    # Zoom
+    $zoomCachePath = "$env:APPDATA\Zoom\data"
+    if (Test-Path $zoomCachePath) {
+        Clear-DirectoryContents -Path $zoomCachePath -Description "Zoom cache"
+    }
+    
+    # Adobe Creative Cloud
+    $adobeCachePaths = @(
+        "$env:LOCALAPPDATA\Adobe\*\Cache"
+        "$env:APPDATA\Adobe\Common\Media Cache Files"
+        "$env:APPDATA\Adobe\Common\Peak Files"
+    )
+    foreach ($pattern in $adobeCachePaths) {
+        $paths = Resolve-Path $pattern -ErrorAction SilentlyContinue
+        foreach ($path in $paths) {
+            if (Test-Path $path) {
+                Clear-DirectoryContents -Path $path.Path -Description "Adobe cache"
+            }
+        }
+    }
+    
+    # Steam (download cache, not games)
+    $steamCachePath = "${env:ProgramFiles(x86)}\Steam\appcache"
+    if (Test-Path $steamCachePath) {
+        Clear-DirectoryContents -Path $steamCachePath -Description "Steam app cache"
+    }
+    
+    # Epic Games Launcher
+    $epicCachePath = "$env:LOCALAPPDATA\EpicGamesLauncher\Saved\webcache"
+    if (Test-Path $epicCachePath) {
+        Clear-DirectoryContents -Path $epicCachePath -Description "Epic Games cache"
+    }
+    
+    Stop-Section
+}
+
+# ============================================================================
+# Windows Store / UWP App Caches
+# ============================================================================
+
+function Clear-StoreAppCaches {
+    <#
+    .SYNOPSIS
+        Clean Windows Store and UWP app caches
+    #>
+    
+    # Microsoft Store cache
+    $storeCache = "$env:LOCALAPPDATA\Microsoft\Windows\WCN"
+    if (Test-Path $storeCache) {
+        Clear-DirectoryContents -Path $storeCache -Description "Windows Store cache"
+    }
+    
+    # Store app temp files
+    $storeTemp = "$env:LOCALAPPDATA\Packages\Microsoft.WindowsStore_*\LocalCache"
+    $storePaths = Resolve-Path $storeTemp -ErrorAction SilentlyContinue
+    foreach ($path in $storePaths) {
+        if (Test-Path $path.Path) {
+            Clear-DirectoryContents -Path $path.Path -Description "Store LocalCache"
+        }
+    }
+}
+
+# ============================================================================
+# .NET / Runtime Caches
+# ============================================================================
+
+function Clear-DotNetCaches {
+    <#
+    .SYNOPSIS
+        Clean .NET runtime caches
+    #>
+    
+    # .NET temp files
+    $dotnetTemp = "$env:LOCALAPPDATA\Temp\Microsoft.NET"
+    if (Test-Path $dotnetTemp) {
+        Clear-DirectoryContents -Path $dotnetTemp -Description ".NET temp files"
+    }
+    
+    # NGen cache (don't touch - managed by Windows)
+    # Assembly cache (don't touch - managed by CLR)
+}
+
+# ============================================================================
+# GPU Shader Caches
+# ============================================================================
+
+function Clear-GPUShaderCaches {
+    <#
+    .SYNOPSIS
+        Clean GPU shader caches (NVIDIA, AMD, Intel, DirectX)
+    .DESCRIPTION
+        GPU drivers cache compiled shaders to improve game/app load times.
+        These caches can grow very large (10GB+) and are safe to delete.
+        They will be rebuilt automatically when needed.
+    #>
+    
+    Start-Section "GPU shader caches"
+    
+    # NVIDIA shader caches
+    $nvidiaCachePaths = @(
+        "$env:LOCALAPPDATA\NVIDIA\DXCache"
+        "$env:LOCALAPPDATA\NVIDIA\GLCache"
+        "$env:LOCALAPPDATA\NVIDIA Corporation\NV_Cache"
+        "$env:TEMP\NVIDIA Corporation\NV_Cache"
+    )
+    foreach ($path in $nvidiaCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "NVIDIA shader cache"
+        }
+    }
+    
+    # AMD shader caches
+    $amdCachePaths = @(
+        "$env:LOCALAPPDATA\AMD\DXCache"
+        "$env:LOCALAPPDATA\AMD\GLCache"
+        "$env:LOCALAPPDATA\AMD\VkCache"
+    )
+    foreach ($path in $amdCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "AMD shader cache"
+        }
+    }
+    
+    # Intel shader caches
+    $intelCachePaths = @(
+        "$env:LOCALAPPDATA\Intel\ShaderCache"
+        "$env:APPDATA\Intel\ShaderCache"
+    )
+    foreach ($path in $intelCachePaths) {
+        if (Test-Path $path) {
+            Clear-DirectoryContents -Path $path -Description "Intel shader cache"
+        }
+    }
+    
+    # DirectX shader cache (system-wide)
+    $dxCachePath = "$env:LOCALAPPDATA\D3DSCache"
+    if (Test-Path $dxCachePath) {
+        Clear-DirectoryContents -Path $dxCachePath -Description "DirectX shader cache"
+    }
+    
+    # DirectX pipeline cache
+    $dxPipelinePath = "$env:LOCALAPPDATA\Microsoft\DirectX Shader Cache"
+    if (Test-Path $dxPipelinePath) {
+        Clear-DirectoryContents -Path $dxPipelinePath -Description "DirectX pipeline cache"
+    }
+    
+    # Vulkan pipeline cache (common location)
+    $vulkanCachePath = "$env:LOCALAPPDATA\VulkanCache"
+    if (Test-Path $vulkanCachePath) {
+        Clear-DirectoryContents -Path $vulkanCachePath -Description "Vulkan pipeline cache"
+    }
+    
+    Stop-Section
+}
+
+# ============================================================================
+# Main Cache Cleanup Function
+# ============================================================================
+
+function Invoke-CacheCleanup {
+    <#
+    .SYNOPSIS
+        Run all cache cleanup tasks
+    #>
+    param(
+        [switch]$IncludeWindowsUpdate,
+        [switch]$IncludeBrowsers,
+        [switch]$IncludeApps,
+        [switch]$IncludeGPU
+    )
+    
+    Start-Section "System caches"
+    
+    # Windows system caches (if admin)
+    if (Test-IsAdmin) {
+        if ($IncludeWindowsUpdate) {
+            Clear-WindowsUpdateDownloads
+            Clear-DeliveryOptimizationCache
+        }
+        Clear-FontCache
+    }
+    
+    Clear-StoreAppCaches
+    Clear-DotNetCaches
+    
+    Stop-Section
+    
+    # GPU shader caches
+    if ($IncludeGPU) {
+        Clear-GPUShaderCaches
+    }
+    
+    # Browser caches
+    if ($IncludeBrowsers) {
+        Clear-BrowserCacheFiles
+    }
+    
+    # Application caches
+    if ($IncludeApps) {
+        Clear-CommonAppCaches
+    }
+}
+
+# ============================================================================
+# Exports
+# ============================================================================
+# Functions: Clear-WindowsUpdateDownloads, Clear-BrowserCacheFiles, Clear-CommonAppCaches,
+#            Clear-DeliveryOptimizationCache, Clear-FontCache, Clear-StoreAppCaches,
+#            Clear-DotNetCaches, Clear-GPUShaderCaches, Invoke-CacheCleanup


### PR DESCRIPTION
## Summary

Ports two new cleanup modules from tw93/Mole (windows branch), adapted to WinMole naming conventions, and wires them into the clean command orchestrator.

## New Files

### lib/clean/caches.ps1 (464 lines)
- GPU shader cache cleanup (NVIDIA, AMD, Intel, DirectX, Vulkan)
- Browser cache files (Chrome, Edge, Firefox, Brave, Opera)
- Common app caches (Spotify, Discord, Slack, Teams, VS Code, Zoom, Adobe, Steam, Epic)
- Windows Store/UWP app caches
- .NET compilation caches
- Delivery Optimization cache
- Font cache cleanup
- Orchestrator function: `Invoke-CacheCleanup`

### lib/clean/apps.ps1 (714 lines)
- Orphaned app data detection (compares AppData folders against installed programs)
- Productivity apps (Office, OneDrive, Dropbox, Google Drive)
- Creative tools (Adobe, Autodesk)
- Gaming platform caches (Steam, Epic, EA, GOG, Ubisoft, Battle.net)
- Game media cleanup (ShadowPlay, AMD ReLive, Xbox Game Bar, OBS, Medal.tv, Overwolf)
- Orchestrator function: `Invoke-AppCleanup`

## Modified Files

### bin/clean.ps1
- Added imports for `caches.ps1` and `apps.ps1`
- New flags: `-Caches`, `-GPUShaders`, `-GameMedia`, `-Orphaned`
- Updated interactive menu with new categories (Cache Clean, Game Media Clean, Orphaned Apps)
- Wired orchestrator to call new module functions
- Full Clean mode now includes all new cleanup categories

## Design Notes

- Functions in caches.ps1 that overlap with user.ps1 are renamed to avoid conflicts (e.g., `Clear-BrowserCacheFiles` instead of `Clear-BrowserCaches`). user.ps1 will be refactored in a later PR.
- Both new modules have multiple-sourcing guards and self-import their dependencies.
- All files pass PowerShell syntax validation and all 48 Pester tests pass.