### PR TITLE
fix: stabilize clean command entrypoints and orphaned app detection

### DIFF
--- a/bin/clean.ps1
+++ b/bin/clean.ps1
@@ -76,6 +76,117 @@ function Show-CleanHelp {
 }
 
 # ============================================================================
+# Compatibility
+# ============================================================================
+
+function Invoke-UserCacheCleanup {
+    <#
+    .SYNOPSIS
+        Run user cache cleanup across mixed install versions.
+    #>
+
+    if (Get-Command -Name "Clear-UserCaches" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-UserCaches
+        return
+    }
+
+    Start-Section "User caches"
+
+    if (Get-Command -Name "Clear-ThumbnailCache" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-ThumbnailCache
+    }
+
+    if (Get-Command -Name "Clear-ClipboardHistory" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-ClipboardHistory
+    }
+
+    Stop-Section
+}
+
+function Invoke-BrowserCacheCleanup {
+    <#
+    .SYNOPSIS
+        Run browser cache cleanup across mixed module versions.
+    #>
+
+    if (Get-Command -Name "Clear-BrowserCaches" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-BrowserCaches
+        return
+    }
+
+    if (Get-Command -Name "Clear-BrowserCacheFiles" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-BrowserCacheFiles
+    }
+}
+
+function Invoke-ApplicationCacheCleanup {
+    <#
+    .SYNOPSIS
+        Run application cache cleanup across mixed module versions.
+    #>
+
+    if (Get-Command -Name "Clear-ApplicationCaches" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-ApplicationCaches
+        return
+    }
+
+    if (Get-Command -Name "Clear-CommonAppCaches" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-CommonAppCaches
+    }
+}
+
+function Invoke-WindowsUpdateCleanup {
+    <#
+    .SYNOPSIS
+        Run Windows Update cache cleanup across mixed module versions.
+    #>
+
+    if (Get-Command -Name "Clear-WindowsUpdateCache" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-WindowsUpdateCache
+        return
+    }
+
+    if (Get-Command -Name "Clear-WindowsUpdateDownloads" -CommandType Function -ErrorAction SilentlyContinue) {
+        Clear-WindowsUpdateDownloads
+    }
+}
+
+function Invoke-DeveloperCleanup {
+    <#
+    .SYNOPSIS
+        Run developer cache cleanup across mixed module versions.
+    #>
+
+    if (Get-Command -Name "Invoke-DevCleanup" -CommandType Function -ErrorAction SilentlyContinue) {
+        Invoke-DevCleanup -All
+        return
+    }
+
+    if (Get-Command -Name "Invoke-DevToolsCleanup" -CommandType Function -ErrorAction SilentlyContinue) {
+        Invoke-DevToolsCleanup
+    }
+}
+
+function Invoke-SystemCleanupCompat {
+    <#
+    .SYNOPSIS
+        Run system cleanup across mixed module versions.
+    #>
+
+    if (Get-Command -Name "Invoke-SystemCleanup" -CommandType Function -ErrorAction SilentlyContinue) {
+        $command = Get-Command -Name "Invoke-SystemCleanup" -CommandType Function -ErrorAction SilentlyContinue
+        $hasAllParameter = $command -and $command.Parameters.ContainsKey("All")
+
+        if ($hasAllParameter) {
+            Invoke-SystemCleanup -All
+        }
+        else {
+            Invoke-SystemCleanup -IncludeComponentStore -IncludeDiskCleanup
+        }
+    }
+}
+
+# ============================================================================
 # Interactive Mode
 # ============================================================================
 
@@ -222,16 +333,16 @@ function Main {
     
     # Run cleanups
     if ($cleanUser) {
-        Clear-UserCaches
+        Invoke-UserCacheCleanup
         Clear-UserLogs
     }
     
     if ($cleanBrowsers) {
-        Clear-BrowserCaches
+        Invoke-BrowserCacheCleanup
     }
     
     if ($cleanApps) {
-        Clear-ApplicationCaches
+        Invoke-ApplicationCacheCleanup
         # Extended app cleanup: productivity, creative, gaming platform caches
         Invoke-AppCleanup
     }
@@ -251,12 +362,12 @@ function Main {
     }
     
     if ($cleanDev) {
-        Invoke-DevCleanup -All
+        Invoke-DeveloperCleanup
     }
     
     if ($cleanSystem) {
         if (Test-IsAdmin) {
-            Invoke-SystemCleanup -All
+            Invoke-SystemCleanupCompat
         }
         else {
             Write-WinMoleWarning "System cleanup requires admin - skipping"
@@ -270,7 +381,7 @@ function Main {
     
     if ($cleanWinUpdate) {
         if (Test-IsAdmin) {
-            Clear-WindowsUpdateCache
+            Invoke-WindowsUpdateCleanup
         }
         else {
             Write-WinMoleWarning "Windows Update cleanup requires admin - skipping"

--- a/lib/clean/apps.ps1
+++ b/lib/clean/apps.ps1
@@ -34,7 +34,10 @@ function Get-InstalledPrograms {
     
     foreach ($path in $registryPaths) {
         $items = Get-ItemProperty -Path $path -ErrorAction SilentlyContinue |
-                 Where-Object { $_.DisplayName } |
+                 Where-Object {
+                     $_.PSObject.Properties.Match('DisplayName').Count -gt 0 -and
+                     -not [string]::IsNullOrWhiteSpace($_.DisplayName)
+                 } |
                  Select-Object DisplayName, InstallLocation, Publisher
         if ($items) {
             $programs += $items

--- a/tests/WinMole.Tests.ps1
+++ b/tests/WinMole.Tests.ps1
@@ -297,7 +297,8 @@ Describe "Cleanup Modules" {
 
             Mock Get-AppxPackage { @() }
 
-            { $result = Get-InstalledPrograms } | Should -Not -Throw
+            { Get-InstalledPrograms | Out-Null } | Should -Not -Throw
+            $result = Get-InstalledPrograms
             @($result).Count | Should -Be 3
             @($result | Where-Object { $_.DisplayName -eq "Named App" }).Count | Should -Be 3
         }
@@ -315,9 +316,9 @@ Describe "Integration Tests" -Tag "Integration" {
             $env:WINMOLE_DRY_RUN = "1"
             try {
                 # This should not actually delete anything
-                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -User -DryRun 2>&1
-                # Should complete without error
-                $LASTEXITCODE | Should -BeIn @(0, $null)
+                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -User -DryRun 2>&1 | Out-String
+                $output | Should -Not -Match "An error occurred"
+                $output | Should -Not -Match "is not recognized as"
             }
             finally {
                 Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue

--- a/tests/WinMole.Tests.ps1
+++ b/tests/WinMole.Tests.ps1
@@ -273,6 +273,38 @@ Describe "Commands" {
 }
 
 # ============================================================================
+# Cleanup Module Tests
+# ============================================================================
+
+Describe "Cleanup Modules" {
+
+    BeforeAll {
+        . "$script:LIB_DIR\clean\apps.ps1"
+    }
+
+    Context "Get-InstalledPrograms" {
+        It "ignores registry entries without DisplayName under strict mode" {
+            Mock Get-ItemProperty {
+                @(
+                    [pscustomobject]@{ Publisher = "NoName Publisher" }
+                    [pscustomobject]@{
+                        DisplayName     = "Named App"
+                        InstallLocation = "C:\Tools\NamedApp"
+                        Publisher       = "Named Publisher"
+                    }
+                )
+            }
+
+            Mock Get-AppxPackage { @() }
+
+            { $result = Get-InstalledPrograms } | Should -Not -Throw
+            @($result).Count | Should -Be 3
+            @($result | Where-Object { $_.DisplayName -eq "Named App" }).Count | Should -Be 3
+        }
+    }
+}
+
+# ============================================================================
 # Integration Tests
 # ============================================================================
 
@@ -286,6 +318,30 @@ Describe "Integration Tests" -Tag "Integration" {
                 $output = & (Join-Path $script:BIN_DIR "clean.ps1") -User -DryRun 2>&1
                 # Should complete without error
                 $LASTEXITCODE | Should -BeIn @(0, $null)
+            }
+            finally {
+                Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue
+            }
+        }
+
+        It "clean browser dry run completes" {
+            $env:WINMOLE_DRY_RUN = "1"
+            try {
+                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -Browsers -DryRun 2>&1 | Out-String
+                $output | Should -Not -Match "is not recognized as"
+                $output | Should -Not -Match "An error occurred"
+            }
+            finally {
+                Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue
+            }
+        }
+
+        It "clean developer dry run completes" {
+            $env:WINMOLE_DRY_RUN = "1"
+            try {
+                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -Dev -DryRun 2>&1 | Out-String
+                $output | Should -Not -Match "is not recognized as"
+                $output | Should -Not -Match "An error occurred"
             }
             finally {
                 Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- add compatibility wrappers in `bin/clean.ps1` for renamed cleanup functions
- fix `Get-InstalledPrograms` under StrictMode when registry entries lack `DisplayName`
- add regression coverage for cleanup command smoke paths
- fix Pester 5 compatibility in cleanup smoke tests

## Verification
- ran `Invoke-Pester -Path .\tests\`
- result: 51 passed, 0 failed
- verified under Pester 5.7.1 on PowerShell 7.5.4

## Notes
- the local repo currently uses `master`, while `CONTRIBUTING.md` says PRs should target `main`; use the upstream default branch shown on GitHub
