### PR TITLE
feat: add Clear-UserCaches helper

### DIFF
--- a/lib/clean/user.ps1
+++ b/lib/clean/user.ps1
@@ -307,6 +307,24 @@ function Clear-ClipboardHistory {
 }
 
 # ============================================================================
+# User Caches Cleanup
+# ============================================================================
+
+function Clear-UserCaches {
+    <#
+    .SYNOPSIS
+        Clean user-level caches (thumbnail, icon, clipboard)
+    #>
+    
+    Start-Section "User caches"
+    
+    Clear-ThumbnailCache
+    Clear-ClipboardHistory
+    
+    Stop-Section
+}
+
+# ============================================================================
 # Main User Cleanup Function
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- add `Clear-UserCaches` to the user cleanup module
- group thumbnail and clipboard cleanup under a single helper
- align the module API with the cleanup command entrypoint

## Notes
- this is a small follow-up change to make the user cleanup module expose the helper directly
