### PR TITLE
fix(analyze): report true directory sizes instead of shallow estimates

### DIFF
--- a/cmd/analyze/main.go
+++ b/cmd/analyze/main.go
@@ -14,17 +14,19 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// Scanning limits to prevent infinite scanning
+// Scanning limits. These are runaway guards, not accuracy trade-offs: a
+// directory is walked to its full depth so reported sizes match Explorer.
+// Sibling directories are sized concurrently, so the timeout below bounds
+// wall-clock time for the whole listing, not the sum of its entries.
 const (
-	dirSizeTimeout   = 500 * time.Millisecond // Max time to calculate a single directory size
-	maxFilesPerDir   = 10000                  // Max files to scan per directory
-	maxScanDepth     = 10                     // Max recursion depth (shallow scan)
-	shallowScanDepth = 3                      // Depth for quick size estimation
+	dirSizeTimeout = 15 * time.Second // Max time to size a single directory
+	maxFilesPerDir = 2000000          // Runaway guard on files per directory tree
 )
 
 // ANSI color codes
@@ -150,6 +152,7 @@ type dirEntry struct {
 	IsDir       bool
 	LastAccess  time.Time
 	IsCleanable bool
+	Partial     bool // Size is a lower bound: the walk hit the timeout or an unreadable subtree
 }
 
 type fileEntry struct {
@@ -426,8 +429,21 @@ func (m model) View() string {
 		b.WriteString("\n")
 	}
 
-	// Total size
-	b.WriteString(fmt.Sprintf("  Total: %s%s%s\n", colorYellow, formatBytes(m.totalSize), colorReset))
+	// Total size. Flag it as a lower bound when any child was truncated, so an
+	// under-count is visible rather than silently wrong.
+	anyPartial := false
+	for _, e := range m.entries {
+		if e.Partial {
+			anyPartial = true
+			break
+		}
+	}
+	if anyPartial {
+		b.WriteString(fmt.Sprintf("  Total: %s≥ %s%s %s(+ = partial: timed out or unreadable)%s\n",
+			colorYellow, formatBytes(m.totalSize), colorReset, colorGray, colorReset))
+	} else {
+		b.WriteString(fmt.Sprintf("  Total: %s%s%s\n", colorYellow, formatBytes(m.totalSize), colorReset))
+	}
 	b.WriteString("\n")
 
 	// Large files toggle
@@ -491,10 +507,15 @@ func (m model) View() string {
 			nameColor = colorCyanBold
 		}
 
+		sizeText := formatBytes(entry.Size)
+		if entry.Partial {
+			sizeText += "+"
+		}
+
 		b.WriteString(fmt.Sprintf("%s%s %s%8s%s %s%s%s %s%.1f%%%s %s\n",
 			prefix,
 			icon,
-			colorYellow, formatBytes(entry.Size), colorReset,
+			colorYellow, sizeText, colorReset,
 			colorGray, bar, colorReset,
 			colorDim, pct, colorReset,
 			nameColor+entry.Name+colorReset,
@@ -599,10 +620,9 @@ func scanDirectory(path string) ([]dirEntry, []fileEntry, int64, error) {
 		name := entry.Name()
 		entryPath := filepath.Join(path, name)
 
-		// Skip system directories
-		if skipPatterns[name] {
-			continue
-		}
+		// System directories are listed and measured like any other. Excluding
+		// them here made the reported total fall far below what Explorer shows;
+		// deletion is guarded separately by isProtectedPath.
 
 		wg.Add(1)
 		sem <- struct{}{}
@@ -614,9 +634,10 @@ func scanDirectory(path string) ([]dirEntry, []fileEntry, int64, error) {
 			var size int64
 			var lastAccess time.Time
 			var isCleanable bool
+			var partial bool
 
 			if isDir {
-				size = calculateDirSize(entryPath)
+				size, partial = calculateDirSize(entryPath)
 				isCleanable = cleanablePatterns[name]
 			} else {
 				info, err := os.Stat(entryPath)
@@ -636,6 +657,7 @@ func scanDirectory(path string) ([]dirEntry, []fileEntry, int64, error) {
 				IsDir:       isDir,
 				LastAccess:  lastAccess,
 				IsCleanable: isCleanable,
+				Partial:     partial,
 			})
 
 			totalSize += size
@@ -667,21 +689,34 @@ func scanDirectory(path string) ([]dirEntry, []fileEntry, int64, error) {
 	return dirEntries, largeFiles, totalSize, nil
 }
 
-// calculateDirSize calculates the size of a directory with timeout and limits
-// Uses shallow scanning for speed - estimates based on first few levels
-func calculateDirSize(path string) int64 {
+// isReparsePoint reports whether info describes a junction, symlink or other
+// reparse point. Recursing into these double-counts space and can loop forever:
+// %LOCALAPPDATA%\Application Data is a junction back to its own parent.
+func isReparsePoint(info os.FileInfo) bool {
+	if d, ok := info.Sys().(*syscall.Win32FileAttributeData); ok {
+		return d.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0
+	}
+	// Fall back to the portable bit if the Windows attributes are unavailable.
+	return info.Mode()&os.ModeSymlink != 0
+}
+
+// calculateDirSize returns the total size of a directory tree. The second
+// result reports whether the walk was cut short by the timeout or the file
+// guard, in which case the size is a lower bound rather than the real total.
+func calculateDirSize(path string) (int64, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), dirSizeTimeout)
 	defer cancel()
 
 	var size int64
 	var fileCount int64
+	var truncated atomic.Bool
 
 	// Use a channel to signal completion
 	done := make(chan struct{})
 
 	go func() {
 		defer close(done)
-		quickScanDir(ctx, path, 0, &size, &fileCount)
+		walkDirSize(ctx, path, &size, &fileCount, &truncated)
 	}()
 
 	select {
@@ -689,32 +724,38 @@ func calculateDirSize(path string) int64 {
 		// Completed normally
 	case <-ctx.Done():
 		// Timeout - return partial size (already accumulated)
+		truncated.Store(true)
 	}
 
-	return size
+	return atomic.LoadInt64(&size), truncated.Load()
 }
 
-// quickScanDir does a fast shallow scan for size estimation
-func quickScanDir(ctx context.Context, path string, depth int, size *int64, fileCount *int64) {
+// walkDirSize sums every file in a directory tree. It walks to full depth and
+// does not filter by name: skipPatterns exists to keep the *delete* path away
+// from system directories, and applying it here was hiding real space (for
+// example AppData\Local\Microsoft\Windows, which matched the bare name
+// "Windows" at every level). Dot-directories are counted too; .gradle, .nuget
+// and friends are often the largest thing in a user profile.
+func walkDirSize(ctx context.Context, path string, size *int64, fileCount *int64, truncated *atomic.Bool) {
 	// Check context cancellation
 	select {
 	case <-ctx.Done():
+		truncated.Store(true)
 		return
 	default:
 	}
 
-	// Limit depth for speed
-	if depth > shallowScanDepth {
-		return
-	}
-
 	// Limit total files scanned
 	if atomic.LoadInt64(fileCount) > maxFilesPerDir {
+		truncated.Store(true)
 		return
 	}
 
 	entries, err := os.ReadDir(path)
 	if err != nil {
+		// Unreadable subtree (permissions, locked file): its contents are
+		// missing from the total, so the caller must not trust the number.
+		truncated.Store(true)
 		return
 	}
 
@@ -722,29 +763,32 @@ func quickScanDir(ctx context.Context, path string, depth int, size *int64, file
 		// Check cancellation
 		select {
 		case <-ctx.Done():
+			truncated.Store(true)
 			return
 		default:
 		}
 
 		if atomic.LoadInt64(fileCount) > maxFilesPerDir {
+			truncated.Store(true)
 			return
 		}
 
 		entryPath := filepath.Join(path, entry.Name())
 
+		info, err := entry.Info()
+		if err != nil {
+			truncated.Store(true)
+			continue
+		}
+
 		if entry.IsDir() {
-			name := entry.Name()
-			// Skip hidden and system directories
-			if skipPatterns[name] || (strings.HasPrefix(name, ".") && len(name) > 1) {
+			if isReparsePoint(info) {
 				continue
 			}
-			quickScanDir(ctx, entryPath, depth+1, size, fileCount)
+			walkDirSize(ctx, entryPath, size, fileCount, truncated)
 		} else {
-			info, err := entry.Info()
-			if err == nil {
-				atomic.AddInt64(size, info.Size())
-				atomic.AddInt64(fileCount, 1)
-			}
+			atomic.AddInt64(size, info.Size())
+			atomic.AddInt64(fileCount, 1)
 		}
 	}
 }

--- a/cmd/analyze/main_test.go
+++ b/cmd/analyze/main_test.go
@@ -1,0 +1,152 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile creates a file of exactly size bytes, making parents as needed.
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestCalculateDirSizeCountsDeepTree covers the primary cause of issue #13:
+// sizes were computed with a depth cap of 3, so anything deeper was invisible.
+// A real profile nests much deeper than that (AppData\Local\Packages\<app>\...).
+func TestCalculateDirSizeCountsDeepTree(t *testing.T) {
+	root := t.TempDir()
+
+	// One file at each level, 1 KiB each, well past the old shallow cap.
+	want := 0
+	path := root
+	for depth := 0; depth < 12; depth++ {
+		path = filepath.Join(path, "level")
+		writeFile(t, filepath.Join(path, "f.bin"), 1024)
+		want += 1024
+	}
+
+	got, partial := calculateDirSize(root)
+	if partial {
+		t.Errorf("scan reported partial for a small tree")
+	}
+	if got != int64(want) {
+		t.Errorf("size = %d, want %d (deep files were skipped)", got, want)
+	}
+}
+
+// TestCalculateDirSizeCountsSystemNamedDirs covers the second cause: skipPatterns
+// was matched on the bare directory name at every depth, so a nested directory
+// called "Windows" was dropped. %LOCALAPPDATA%\Microsoft\Windows is exactly this
+// case and holds INetCache, WebCache and Explorer thumbnails.
+func TestCalculateDirSizeCountsSystemNamedDirs(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "Microsoft", "Windows", "INetCache", "a.bin"), 4096)
+	writeFile(t, filepath.Join(root, "Program Files", "b.bin"), 2048)
+	writeFile(t, filepath.Join(root, "ProgramData", "c.bin"), 1024)
+
+	got, _ := calculateDirSize(root)
+	if want := int64(4096 + 2048 + 1024); got != want {
+		t.Errorf("size = %d, want %d (system-named subdirectories were skipped)", got, want)
+	}
+}
+
+// TestCalculateDirSizeCountsDotDirs covers the third cause: directories starting
+// with "." were skipped as "hidden", but .gradle/.nuget/.cache are frequently
+// the largest thing in a user profile.
+func TestCalculateDirSizeCountsDotDirs(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, ".gradle", "caches", "big.bin"), 8192)
+	writeFile(t, filepath.Join(root, "visible", "small.bin"), 512)
+
+	got, _ := calculateDirSize(root)
+	if want := int64(8192 + 512); got != want {
+		t.Errorf("size = %d, want %d (dot-directories were skipped)", got, want)
+	}
+}
+
+// TestCalculateDirSizeSkipsJunctionLoop guards the change that made a full-depth
+// walk safe. %LOCALAPPDATA%\Application Data is a junction pointing at its own
+// parent; without the reparse-point check, removing the depth cap would recurse
+// until the path length limit. The old depth cap was masking this.
+func TestCalculateDirSizeSkipsJunctionLoop(t *testing.T) {
+	root := t.TempDir()
+
+	real := filepath.Join(root, "real")
+	writeFile(t, filepath.Join(real, "f.bin"), 2048)
+
+	// Junctions (unlike symlinks) do not require elevation.
+	link := filepath.Join(root, "loop")
+	if err := exec.Command("cmd", "/c", "mklink", "/J", link, root).Run(); err != nil {
+		t.Skipf("could not create junction (needed for this test): %v", err)
+	}
+
+	got, _ := calculateDirSize(root)
+	if want := int64(2048); got != want {
+		t.Errorf("size = %d, want %d (junction was followed and double-counted)", got, want)
+	}
+}
+
+// TestScanDirectoryListsSystemDirs covers the reported symptom that whole
+// directories were missing from the listing: scanDirectory dropped any entry
+// matching skipPatterns, so analyzing C:\ omitted Windows and Program Files
+// from both the list and the total.
+func TestScanDirectoryListsSystemDirs(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "Windows", "a.bin"), 1024)
+	writeFile(t, filepath.Join(root, "Program Files", "b.bin"), 1024)
+	writeFile(t, filepath.Join(root, "AppData", "c.bin"), 1024)
+
+	entries, _, total, err := scanDirectory(root)
+	if err != nil {
+		t.Fatalf("scanDirectory: %v", err)
+	}
+
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		seen[e.Name] = true
+	}
+	for _, name := range []string{"Windows", "Program Files", "AppData"} {
+		if !seen[name] {
+			t.Errorf("entry %q missing from listing", name)
+		}
+	}
+	if want := int64(3072); total != want {
+		t.Errorf("total = %d, want %d", total, want)
+	}
+}
+
+// TestIsProtectedPathStillGuardsSystemDirs pins the safety boundary: measuring
+// system directories is now allowed, but deleting them must still be refused.
+func TestIsProtectedPathStillGuardsSystemDirs(t *testing.T) {
+	for _, p := range []string{
+		`C:\Windows`,
+		`C:\Windows\System32`,
+		`C:\Program Files`,
+		`C:\Program Files (x86)\Something`,
+		`C:\ProgramData`,
+		`C:\Users\Default`,
+	} {
+		if !isProtectedPath(p) {
+			t.Errorf("isProtectedPath(%q) = false, want true", p)
+		}
+	}
+
+	// A user directory that merely shares a system name must stay deletable.
+	unprotected := filepath.Join(t.TempDir(), "project", "build")
+	if isProtectedPath(unprotected) {
+		t.Errorf("isProtectedPath(%q) = true, want false", unprotected)
+	}
+}


### PR DESCRIPTION
Fixes #13.

## The report

Reported disk utilization was substantially lower than Explorer, worse at deeper levels, with `AppData` and `OneDrive` appearing skipped from the `Users` level and `WSL` missing from `AppData\Local` until navigated into directly.

## Root causes

Four independent bugs in the size walk, all compounding:

1. **Depth capped at 3** (`shallowScanDepth`). A user profile nests far past that - `AppData\Local\Packages\<app>\LocalState\...` was simply invisible. This is the "worse at deeper levels" symptom.
2. **`skipPatterns` matched the bare directory name at every depth.** A nested directory called `Windows` was dropped, which silently removed `AppData\{Local,Roaming}\Microsoft\Windows` - INetCache, WebCache and Explorer thumbnails.
3. **Dot-directories skipped as "hidden"**, excluding `.gradle`, `.nuget`, `.cache` - frequently the largest items in a profile.
4. **Budget of 500ms and 10,000 files per directory**, both routinely exceeded by a single `AppData` subtree, with the truncated result returned as if it were the real total.

Separately, `scanDirectory` dropped `skipPatterns` entries from the **listing** itself, so analyzing `C:\` omitted `Windows` and `Program Files` from both the list and the total. That is the headline "total far below Explorer" symptom.

## Changes

- Size walks run to full depth; `skipPatterns` is no longer consulted for measurement. It exists to keep the *delete* path away from system directories, and `isProtectedPath` still does that job unchanged.
- System directories are listed and measured like any other.
- Reparse points (junctions and symlinks) are now skipped. This is **required** for a full-depth walk: `%LOCALAPPDATA%\Application Data` is a junction back to its own parent, and the old depth cap had been masking an infinite recursion. Trees are now counted exactly once and cannot loop.
- Per-directory budget raised to 15s / 2M files as a runaway guard rather than an accuracy trade-off. Siblings are sized concurrently, so this bounds wall-clock time for the listing, not the sum of its entries.
- Truncated or unreadable scans are now **visible**: the entry shows `+` and the total shows `>= X`, instead of silently reporting a wrong number as authoritative.

## Verification

Measured against an independent PowerShell sum of the same tree:

```
winmole:     3,118,830,054 bytes  (partial=false, 0.56s)
PowerShell:  3,118,830,054 bytes  (19,570 files)
```

Exact match on `AppData\Local\Microsoft` - a tree that previously tripped the file cap, the depth cap and the nested-`Windows` skip simultaneously.

Adds `cmd/analyze/main_test.go` with one regression test per root cause, plus one pinning that `isProtectedPath` still refuses to delete system directories now that they are scannable. `go build`, `go vet` and `gofmt` clean; existing Pester suite still 48/48.