### PR TITLE
fix(core): stop shadowing Write-Progress, add CI guard for unresolved calls

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,6 +35,21 @@ jobs:
           }
           Write-Host "All PowerShell scripts are syntactically valid" -ForegroundColor Green
 
+  commands:
+    name: Command Resolution
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # A call to a nonexistent function, or one passing an undeclared
+      # parameter, is valid syntax and passes the check above. It only fails when
+      # that branch runs, which is how #14 survived on master for months.
+      - name: Check every command and parameter resolves
+        shell: pwsh
+        run: pwsh -NoProfile -File ./scripts/check-commands.ps1
+
   go-build:
     name: Go Build
     runs-on: windows-latest

--- a/bin/purge.ps1
+++ b/bin/purge.ps1
@@ -213,9 +213,8 @@ function Find-Projects {
 
     foreach ($searchPath in $SearchPaths) {
         $pathCount++
-        Write-Progress -Activity "Scanning for projects" `
-            -Status "Searching: $searchPath" `
-            -PercentComplete (($pathCount / $totalPaths) * 100)
+        Write-ProgressBar -Current $pathCount -Total $totalPaths `
+            -Message "Searching: $searchPath"
 
         foreach ($marker in $projectMarkers) {
             try {
@@ -256,7 +255,7 @@ function Find-Projects {
         }
     }
 
-    Write-Progress -Activity "Scanning for projects" -Completed
+    Complete-Progress
 
     # Sort by size (largest first)
     return $projects | Sort-Object -Property TotalSizeKB -Descending

--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -133,7 +133,9 @@ function Get-InstalledApplications {
 
     foreach ($path in $registryPaths) {
         $count++
-        Write-Progress -Activity "Scanning applications" -Status "Registry path $count of $total" -PercentComplete (($count / $total) * 50)
+        # Registry scanning is the first half of the overall scan, so the total is
+        # doubled to keep this stage within 0-50%, matching the previous intent.
+        Write-ProgressBar -Current $count -Total ($total * 2) -Message "Registry path $count of $total"
 
         try {
             $regItems = Get-ItemProperty -Path $path -ErrorAction SilentlyContinue
@@ -203,7 +205,7 @@ function Get-InstalledApplications {
     }
 
     # UWP / Store Apps
-    Write-Progress -Activity "Scanning applications" -Status "Scanning Windows Apps" -PercentComplete 75
+    Write-ProgressBar -Current 3 -Total 4 -Message "Scanning Windows Apps"
 
     try {
         $uwpApps = Get-AppxPackage -ErrorAction SilentlyContinue |
@@ -249,7 +251,7 @@ function Get-InstalledApplications {
         Write-Debug "Could not enumerate UWP apps: $_"
     }
 
-    Write-Progress -Activity "Scanning applications" -Completed
+    Complete-Progress
 
     # Sort by size (largest first)
     $apps = $apps | Sort-Object -Property SizeKB -Descending

--- a/lib/core/log.ps1
+++ b/lib/core/log.ps1
@@ -252,26 +252,42 @@ function Stop-Spinner {
 # Progress Bar
 # ============================================================================
 
-function Write-Progress {
+# Deliberately NOT named Write-Progress. Functions outrank cmdlets in PowerShell
+# command resolution, so a function by that name silently shadows the built-in
+# cmdlet for every script that dot-sources this file. Callers passing the
+# cmdlet's parameters (-Activity/-Status/-PercentComplete) then bound here
+# instead, and because the function was not an advanced function those arguments
+# were absorbed into $args and discarded, leaving the bar frozen at 0%.
+function Write-ProgressBar {
     <#
     .SYNOPSIS
-        Write a progress bar
+        Write an inline progress bar
+    .PARAMETER Current
+        Items completed so far.
+    .PARAMETER Total
+        Total items expected. Values below 1 render as 0%.
     #>
+    [CmdletBinding()]
     param(
         [int]$Current,
         [int]$Total,
         [string]$Message = "",
         [int]$Width = 30
     )
-    
+
     $percent = if ($Total -gt 0) { [Math]::Round(($Current / $Total) * 100) } else { 0 }
+
+    # Clamp before building the bar: "=" * -1 throws, and $Current can exceed
+    # $Total when a caller discovers more items partway through a scan.
     $filled = [Math]::Round(($Width * $Current) / [Math]::Max($Total, 1))
+    if ($filled -lt 0) { $filled = 0 }
+    if ($filled -gt $Width) { $filled = $Width }
     $empty = $Width - $filled
-    
+
     $bar = ("[" + ("=" * $filled) + (" " * $empty) + "]")
     $cyan = $script:Colors.Cyan
     $nc = $script:Colors.NC
-    
+
     Write-Host -NoNewline "`r  ${cyan}$bar${nc} ${percent}% $Message    "
 }
 
@@ -280,7 +296,10 @@ function Complete-Progress {
     .SYNOPSIS
         Clear the progress bar line
     #>
-    Write-Host -NoNewline "`r" + (" " * 80) + "`r"
+    # The parentheses are required. Without them PowerShell parses this in
+    # argument mode and passes "`r", "+", the spaces, "+", "`r" as five separate
+    # arguments, printing literal plus signs instead of clearing the line.
+    Write-Host -NoNewline ("`r" + (" " * 80) + "`r")
 }
 
 # ============================================================================

--- a/scripts/check-commands.ps1
+++ b/scripts/check-commands.ps1
@@ -1,0 +1,206 @@
+# WinMole - Static command resolution check
+#
+# PowerShell resolves command names at call time, so a call to a function that
+# does not exist, or a call passing a parameter that was never declared, is
+# perfectly valid syntax and parses cleanly. It only fails when that specific
+# branch executes. Issue #14 reached master and survived for months exactly this
+# way: six calls in bin/clean.ps1 were broken and every syntax check passed.
+#
+# This script parses every script under bin/ and lib/ and fails the build when:
+#   1. A Verb-Noun invocation resolves to neither a repo function nor a real
+#      cmdlet, alias or application.
+#   2. A call to a repo function passes a named parameter that function does not
+#      declare. This is the subtler case: `Invoke-SystemCleanup -All` names a
+#      real function, so a name-only search finds nothing wrong.
+#
+# Usage:  pwsh -File scripts/check-commands.ps1
+# Exits 0 when clean, 1 when any problem is found.
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$commonParameters = @(
+    'Verbose', 'Debug', 'ErrorAction', 'WarningAction', 'InformationAction',
+    'ErrorVariable', 'WarningVariable', 'InformationVariable', 'OutVariable',
+    'OutBuffer', 'PipelineVariable', 'ProgressAction', 'WhatIf', 'Confirm'
+)
+
+# Calls to names this repo does not define are tolerated only when an enclosing
+# if-condition tests for them with Get-Command, which is how the compatibility
+# shims in bin/clean.ps1 (#11) are written. That is detected structurally below,
+# so no name list is needed and a genuinely broken call cannot hide behind one.
+#
+# Parameter exceptions must name the enclosing function, not just the command.
+# Keying on the command name alone would excuse `Invoke-SystemCleanup -All`
+# anywhere in the repo, including a real mistake; scoping it to the one shim that
+# probes for the parameter at runtime keeps the exception narrow. Tracked in #16
+# for removal once the shims call the real names directly.
+$allowedParameters = @{
+    'Invoke-SystemCleanupCompat:Invoke-SystemCleanup:All' = 'this shim tests for -All via Get-Command before calling'
+}
+
+$files = Get-ChildItem -Path (Join-Path $RepoRoot 'bin'), (Join-Path $RepoRoot 'lib') `
+    -Recurse -Filter *.ps1 -ErrorAction SilentlyContinue
+
+if (-not $files) {
+    Write-Host "No PowerShell files found under bin/ or lib/ - nothing to check." -ForegroundColor Yellow
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Index every function defined in the repo, with its declared parameters
+# ---------------------------------------------------------------------------
+$defined = @{}
+foreach ($file in $files) {
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$null, [ref]$null)
+    $functions = $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
+    foreach ($function in $functions) {
+        $names = @()
+        if ($function.Parameters) {
+            $names += $function.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath }
+        }
+        if ($function.Body.ParamBlock -and $function.Body.ParamBlock.Parameters) {
+            $names += $function.Body.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath }
+        }
+        $defined[$function.Name] = @{
+            Parameters = @($names | Sort-Object -Unique)
+            File       = $file.FullName.Substring($RepoRoot.Length + 1)
+            Line       = $function.Extent.StartLineNumber
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# A call is "guarded" when an enclosing if-condition tests for the command's
+# existence with Get-Command, which is how the #11 shims are written.
+# ---------------------------------------------------------------------------
+function Test-CallIsGuarded {
+    param($CallAst, [string]$Name)
+
+    $node = $CallAst.Parent
+    while ($null -ne $node) {
+        if ($node -is [System.Management.Automation.Language.IfStatementAst]) {
+            foreach ($clause in $node.Clauses) {
+                $condition = $clause.Item1.Extent.Text
+                if ($condition -match 'Get-Command' -and $condition -match [regex]::Escape($Name)) {
+                    return $true
+                }
+            }
+        }
+        $node = $node.Parent
+    }
+    return $false
+}
+
+# Name of the function a call sits inside, or '' at file scope. Used to scope
+# parameter exceptions so they cannot excuse the same mistake elsewhere.
+function Get-EnclosingFunctionName {
+    param($CallAst)
+
+    $node = $CallAst.Parent
+    while ($null -ne $node) {
+        if ($node -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+            return $node.Name
+        }
+        $node = $node.Parent
+    }
+    return ''
+}
+
+$missing = [System.Collections.Generic.List[string]]::new()
+$badParameters = [System.Collections.Generic.List[string]]::new()
+$allowedHits = [System.Collections.Generic.List[string]]::new()
+
+foreach ($file in $files) {
+    $relative = $file.FullName.Substring($RepoRoot.Length + 1)
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$null, [ref]$null)
+    $calls = $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $true)
+
+    foreach ($call in $calls) {
+        $name = $call.GetCommandName()
+        if (-not $name) { continue }
+        if ($name -notmatch '^[A-Z][a-z]+-[A-Za-z]') { continue }
+
+        $line = $call.Extent.StartLineNumber
+        $isRepoFunction = $defined.ContainsKey($name)
+
+        # --- check 1: does the command resolve at all? ---
+        if (-not $isRepoFunction) {
+            $resolves = $null -ne (Get-Command $name -ErrorAction SilentlyContinue)
+            if (-not $resolves) {
+                if (Test-CallIsGuarded -CallAst $call -Name $name) {
+                    $enclosing = Get-EnclosingFunctionName -CallAst $call
+                    $allowedHits.Add("${relative}:${line}  $name  (Get-Command guarded, in $enclosing)")
+                }
+                else {
+                    $missing.Add("${relative}:${line}  $name is not defined in this repo and is not a known command")
+                }
+            }
+            continue
+        }
+
+        # --- check 2: do the named parameters exist on the target function? ---
+        $target = $defined[$name]
+        foreach ($element in $call.CommandElements) {
+            if ($element -isnot [System.Management.Automation.Language.CommandParameterAst]) { continue }
+            $parameter = $element.ParameterName
+            if ($commonParameters -contains $parameter) { continue }
+
+            # PowerShell accepts unambiguous prefixes, so treat those as valid.
+            $matched = @($target.Parameters | Where-Object { $_ -like "$parameter*" })
+            if ($matched.Count -gt 0) { continue }
+
+            $enclosing = Get-EnclosingFunctionName -CallAst $call
+            $key = "${enclosing}:${name}:${parameter}"
+            if ($allowedParameters.ContainsKey($key)) {
+                $allowedHits.Add("${relative}:${line}  $name -$parameter  in $enclosing ($($allowedParameters[$key]))")
+                continue
+            }
+
+            $declared = if ($target.Parameters) { $target.Parameters -join ', ' } else { '(none)' }
+            $badParameters.Add("${relative}:${line}  $name -$parameter is not a parameter of $name (declared: $declared; defined at $($target.File):$($target.Line))")
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+Write-Host "Command resolution check" -ForegroundColor Cyan
+Write-Host "  scanned $($files.Count) files, indexed $($defined.Count) functions"
+Write-Host ""
+
+if ($allowedHits.Count -gt 0) {
+    Write-Host "Allowed exceptions ($($allowedHits.Count)):" -ForegroundColor Yellow
+    foreach ($hit in $allowedHits) { Write-Host "  $hit" }
+    Write-Host ""
+}
+
+$failed = $false
+
+if ($missing.Count -gt 0) {
+    $failed = $true
+    Write-Host "Unresolved commands ($($missing.Count)):" -ForegroundColor Red
+    foreach ($item in $missing) { Write-Host "  $item" }
+    Write-Host ""
+}
+
+if ($badParameters.Count -gt 0) {
+    $failed = $true
+    Write-Host "Parameter binding mismatches ($($badParameters.Count)):" -ForegroundColor Red
+    foreach ($item in $badParameters) { Write-Host "  $item" }
+    Write-Host ""
+}
+
+if ($failed) {
+    Write-Host "FAILED - see above. These would surface only when the affected branch runs." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "PASSED - every command resolves and every named parameter exists." -ForegroundColor Green
+exit 0

--- a/tests/WinMole.Tests.ps1
+++ b/tests/WinMole.Tests.ps1
@@ -306,6 +306,59 @@ Describe "Cleanup Modules" {
 }
 
 # ============================================================================
+# Progress Bar - regression tests for #18
+# ============================================================================
+
+Describe "Progress Bar - log.ps1" {
+
+    BeforeAll {
+        . "$script:LIB_DIR\core\base.ps1"
+        . "$script:LIB_DIR\core\log.ps1"
+    }
+
+    Context "cmdlet shadowing" {
+        It "does not shadow the built-in Write-Progress cmdlet" {
+            # A function named Write-Progress outranks the cmdlet for every script
+            # that dot-sources log.ps1, silently swallowing -Activity/-Status/
+            # -PercentComplete into $args and freezing the bar at 0%.
+            (Get-Command Write-Progress).CommandType | Should -Be 'Cmdlet'
+        }
+
+        It "exposes the helper under a non-colliding name" {
+            (Get-Command Write-ProgressBar).CommandType | Should -Be 'Function'
+        }
+    }
+
+    Context "Write-ProgressBar" {
+        It "renders a percentage that tracks Current over Total" {
+            $rendered = Write-ProgressBar -Current 7 -Total 10 -Message "x" 6>&1 | Out-String
+            $rendered | Should -Match '70%'
+        }
+
+        It "renders 0% when Total is zero rather than dividing by zero" {
+            { Write-ProgressBar -Current 0 -Total 0 6>&1 | Out-Null } | Should -Not -Throw
+            $rendered = Write-ProgressBar -Current 0 -Total 0 6>&1 | Out-String
+            $rendered | Should -Match '0%'
+        }
+
+        It "does not throw when Current exceeds Total" {
+            # Clamping matters because '=' * -1 throws, and callers discover
+            # additional items partway through a scan.
+            { Write-ProgressBar -Current 15 -Total 10 6>&1 | Out-Null } | Should -Not -Throw
+        }
+    }
+
+    Context "Complete-Progress" {
+        It "clears the line without emitting literal plus signs" {
+            # The body concatenates inside parentheses; without them PowerShell
+            # parses it in argument mode and prints "+" between each part.
+            $rendered = Complete-Progress 6>&1 | Out-String
+            $rendered | Should -Not -Match '\+'
+        }
+    }
+}
+
+# ============================================================================
 # Integration Tests
 # ============================================================================
 


### PR DESCRIPTION
Fixes #18. Closes #16.

## The bug (#18)

`lib/core/log.ps1` defined `function Write-Progress`, which **outranks the built-in cmdlet** for every script that dot-sources it. `bin/purge.ps1` and `bin/uninstall.ps1` called it with the cmdlet's parameters across six sites:

```powershell
Write-Progress -Activity "Scanning for projects" -Status "..." -PercentComplete 42
```

The helper takes `-Current/-Total/-Message/-Width` and was **not** an advanced function, so those three arguments were silently absorbed into `$args` and discarded. `Current` and `Total` stayed at their `0` defaults and the bar rendered `[                    ] 0%` forever - no error, no warning.

## The fix

Renamed to `Write-ProgressBar` and marked `[CmdletBinding()]`, so a stray argument now fails loudly rather than vanishing. Renaming rather than reconciling the signature also makes this change safe in both directions: any call site this pass missed now resolves to the real cmdlet and simply works.

Six call sites updated. The two that passed `-Completed` now call `Complete-Progress`, which was the intended counterpart and had never been called from either script.

Before / after:

```
Current=0  -> [                              ] 0% step 0
Current=3  -> [=========                     ] 30% step 3
Current=7  -> [=====================         ] 70% step 7
Current=10 -> [==============================] 100% step 10
```

## Two more defects found in the same code

- **`Complete-Progress` never cleared the line.** Its body was `Write-Host -NoNewline "`r" + (" " * 80) + "`r"`. In argument mode PowerShell passes that as five separate arguments, so it printed literal `+` signs. Verified: emitted `X + ----- + Y` where `X`/`Y` stand in for the carriage returns. Now parenthesised.
- **The bar threw when `Current > Total`.** `$empty = $Width - $filled` went negative and `" " * -1` throws `times ('-1') must be a non-negative value`. Callers legitimately discover more items partway through a scan. Now clamped at both ends.

## The CI guard (#16)

A call to a function that does not exist, or one passing a parameter the target never declared, **is valid PowerShell syntax** and passes the existing `PowerShell Syntax Check`. It fails only when that specific branch executes. That is precisely how #14 reached `master` and survived for months with six broken call sites.

`scripts/check-commands.ps1` parses `bin/` and `lib/`, indexes every function with its declared parameters, and fails on:

1. Verb-Noun invocations resolving to neither a repo function nor a real command.
2. Named parameters the target function does not declare - the subtler case, since `Invoke-SystemCleanup -All` names a real function and a name-only search finds nothing wrong.

Wired in as a `Command Resolution` job.

**On the #11 compatibility shims:** their calls to deliberately-absent names are recognised *structurally*, by walking up the AST for an enclosing `if` condition that tests the name with `Get-Command`. No name allowlist, so a genuinely broken call cannot hide behind one.

The single parameter exception is keyed by **enclosing function name**, not command name. My first version keyed it globally and I caught it excusing an injected `Invoke-SystemCleanup -All` elsewhere in the file - exactly the bug the check exists to find. Now scoped to the one shim that probes for `-All` at runtime.

## Verified both directions

A check that cannot fail is worthless, so I tested both:

- **Passes** on the repo as-is, reporting the 5 legitimate exceptions.
- **Fails with exit 1** on a scratch copy with three reintroduced defects, catching an unresolved command, an out-of-scope `Invoke-SystemCleanup -All`, and a bogus parameter - while still permitting the legitimate guarded shim at line 181.

## Tests

Pester **55/55**, up from 48. Seven new regression tests: that `Write-Progress` resolves to `Cmdlet` (not a function), that the percentage tracks `Current/Total`, zero-total and over-total handling, and that `Complete-Progress` emits no `+`.