### PR TITLE
chore: add community health files, issue/PR templates and CodeQL (salvaged from #10)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: Bug Report
+about: Report a bug to help us improve WinMole
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Run command '...'
+2. Select option '...'
+3. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+What actually happened instead.
+
+## Screenshots / Output
+
+If applicable, add screenshots or paste the terminal output to help explain your problem.
+
+```
+Paste terminal output here
+```
+
+## Environment
+
+- **OS**: [e.g., Windows 11 23H2]
+- **PowerShell Version**: [run `$PSVersionTable.PSVersion`]
+- **WinMole Version**: [if known]
+- **Running as Admin**: [Yes/No]
+
+## Additional Context
+
+Add any other context about the problem here.
+
+## Checklist
+
+- [ ] I have searched existing issues to ensure this is not a duplicate
+- [ ] I have tried running with `-DryRun` to see what would happen
+- [ ] I have tried running with `$env:WINMOLE_DEBUG = 1` for more details

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/bhadraagada/winmole#readme
+    about: Check the README for usage instructions and examples
+  - name: Discussions
+    url: https://github.com/bhadraagada/winmole/discussions
+    about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for WinMole
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Is your feature request related to a problem?
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the Solution You'd Like
+
+A clear and concise description of what you want to happen.
+
+## Describe Alternatives You've Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Use Case
+
+Explain how this feature would benefit users:
+
+- Who would use this feature?
+- How often would it be used?
+- What problem does it solve?
+
+## Proposed Implementation (Optional)
+
+If you have ideas on how to implement this, please share:
+
+```powershell
+# Example code or pseudocode
+```
+
+## Additional Context
+
+Add any other context, screenshots, or mockups about the feature request here.
+
+## Checklist
+
+- [ ] I have searched existing issues to ensure this is not a duplicate
+- [ ] I have considered the security implications of this feature
+- [ ] This feature aligns with WinMole's goal of system maintenance

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,24 @@
+---
+name: Question / Help
+about: Ask a question or get help with WinMole
+title: '[QUESTION] '
+labels: question
+assignees: ''
+---
+
+## Your Question
+
+What would you like to know?
+
+## What have you tried?
+
+Describe any troubleshooting steps you've already attempted.
+
+## Environment
+
+- **OS**: [e.g., Windows 11]
+- **PowerShell Version**: [run `$PSVersionTable.PSVersion`]
+
+## Additional Context
+
+Add any other context here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+## Pull Request
+
+### Description
+
+Brief description of what this PR does.
+
+### Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD changes
+
+### Related Issues
+
+Fixes #(issue number)
+
+### Changes Made
+
+- Change 1
+- Change 2
+- Change 3
+
+### Testing
+
+Describe the tests you ran to verify your changes:
+
+- [ ] Ran `Invoke-Pester -Path .\tests\` and all tests pass
+- [ ] Tested with `-DryRun` to verify behavior
+- [ ] Tested on Windows 10/11
+- [ ] Manual testing performed
+
+### Screenshots (if applicable)
+
+Add screenshots to help explain your changes.
+
+### Checklist
+
+- [ ] My code follows the project's code style (see CONTRIBUTING.md)
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have updated the documentation (if needed)
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing tests pass locally with my changes
+- [ ] I have checked that this PR does not introduce security vulnerabilities
+
+### Safety Checklist (for cleanup/deletion features)
+
+- [ ] Uses `Remove-SafeItem` or other safe helpers (not raw `Remove-Item`)
+- [ ] Respects `Test-ProtectedPath` for system directories
+- [ ] Tested with `-WhatIf` or `-DryRun` first
+- [ ] Does not affect user documents, photos, or personal files

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - go
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,95 @@
+- name: bug
+  color: "d73a4a"
+  description: Something is not working
+
+- name: enhancement
+  color: "a2eeef"
+  description: New feature or request
+
+- name: question
+  color: "d876e3"
+  description: Further information is requested
+
+- name: documentation
+  color: "0075ca"
+  description: Improvements or additions to documentation
+
+- name: security
+  color: "b60205"
+  description: Security-related issue or update
+
+- name: dependencies
+  color: "0366d6"
+  description: Dependency updates
+
+- name: good first issue
+  color: "7057ff"
+  description: Good for newcomers
+
+- name: help wanted
+  color: "008672"
+  description: Extra attention is needed
+
+- name: go
+  color: "00ADD8"
+  description: Go language related
+
+- name: github-actions
+  color: "2088FF"
+  description: GitHub Actions workflow related
+
+- name: powershell
+  color: "012456"
+  description: PowerShell script related
+
+# Triage labels. Kept here so the label set is reproducible rather than existing
+# only as manual edits in the GitHub UI. sync-labels.yml runs with
+# delete-other-labels: false, so adding entries here is additive and safe.
+
+- name: "priority: critical"
+  color: "b60205"
+  description: Silently wrong results or data loss risk; fix before next release
+
+- name: "priority: high"
+  color: "d93f0b"
+  description: User-facing breakage; fix soon
+
+- name: "priority: medium"
+  color: "fbca04"
+  description: Worth fixing, not urgent
+
+- name: "priority: low"
+  color: "0e8a16"
+  description: Nice to have
+
+- name: "area: clean"
+  color: "1d76db"
+  description: bin/clean.ps1 and lib/clean/*
+
+- name: "area: analyze"
+  color: "1d76db"
+  description: cmd/analyze disk analyzer
+
+- name: "area: core"
+  color: "1d76db"
+  description: lib/core/* shared helpers
+
+- name: "area: ci"
+  color: "1d76db"
+  description: GitHub Actions, tests, tooling
+
+- name: "area: packaging"
+  color: "1d76db"
+  description: Installers, releases, distribution
+
+- name: "needs rebase"
+  color: "e99695"
+  description: Stale against master or conflicts with another PR
+
+- name: "stale ci"
+  color: "e99695"
+  description: CI signal expired or never ran; needs re-run
+
+- name: "tech debt"
+  color: "c5def5"
+  description: Structural cleanup, no behaviour change

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: "30 3 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,25 @@
+name: Sync Labels
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, master]
+    paths:
+      - .github/labels.yml
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "ms-vscode.powershell",
+    "golang.go",
+    "ms-vscode.vscode-json",
+    "redhat.vscode-yaml"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "editor.tabSize": 4,
+  "editor.detectIndentation": false,
+  "powershell.codeFormatting.preset": "OTBS",
+  "go.formatTool": "gofmt",
+  "go.useLanguageServer": true
+}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at:
+
+- Open a private security report on GitHub
+- Or open an issue labeled `conduct` if private reporting is not required
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant][homepage], version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the most recent release and for `master`.
+
+| Version          | Supported |
+| ---------------- | --------- |
+| `master`         | yes       |
+| v0.1.0 (current) | yes       |
+| older tags       | no        |
+
+WinMole deletes files and, for some operations, runs with administrator rights,
+so the areas most worth scrutiny are `lib/core/file_ops.ps1`, the protected-path
+checks in `lib/core/base.ps1`, and the delete path in `cmd/analyze`. Reports
+about a path that should be protected but is not are especially welcome.
+
+## Reporting a Vulnerability
+
+Please do not open public issues for security vulnerabilities.
+
+Use one of these channels:
+
+1. GitHub Security Advisories (preferred): open a private vulnerability report in this repository.
+2. If private advisories are unavailable, open an issue and clearly mark it as `SECURITY` with minimal exploit detail, then we will follow up privately.
+
+When reporting, include:
+
+- A clear description of the vulnerability
+- Steps to reproduce
+- Impact assessment
+- Affected files/commands
+- Suggested fix (optional)
+
+## Response Timeline
+
+- Initial acknowledgment: within 72 hours
+- Triage decision: within 7 days
+- Fix target: as soon as practical based on severity
+
+## Scope
+
+Security-sensitive areas in WinMole include:
+
+- Path validation and safe deletion helpers in `lib/core/file_ops.ps1`
+- Protected path checks in `lib/core/base.ps1`
+- Cleanup commands in `bin/*.ps1`
+- Any operation that can delete files or require elevated privileges
+
+## Safe Disclosure
+
+Please avoid publishing proof-of-concept exploits before a fix is available.
+We appreciate responsible disclosure and will credit reporters who want public acknowledgment.


### PR DESCRIPTION
Salvages the still-useful part of #10 and drops the rest. Supersedes that PR.

## Why not just rebase #10

It is 29 commits stale, and master has moved **ahead** of it on every code file it touches:

| File | master vs pr/10 |
|---|---|
| `lib/core/base.ps1` | identical |
| `install.ps1` | identical |
| `lib/core/log.ps1` | master ahead (+23 / -53) |
| `bin/purge.ps1` | master ahead (+352 / -534) |
| `bin/analyze.ps1` | master ahead |

So its code changes are already landed or superseded. Its **scaffolding**, though, is still completely missing from master - so that is what this takes.

## Added

- Issue templates (bug / feature / question) plus chooser config
- Pull request template
- Dependabot for `gomod` and `github-actions`
- CodeQL workflow - Go only, since CodeQL has no PowerShell analyzer
- Label sync workflow
- `CODE_OF_CONDUCT.md`, `SECURITY.md`
- VS Code recommended extensions and settings

## Deliberately not taken from #10

- **The updated `bin/*.exe` binaries.** Committed binaries cannot be reviewed, and the release now publishes them as assets.
- **`CHANGELOG.md`** - already exists with fuller content.
- **The README edits** - would revert the GPL-3.0 licensing section.
- **The workflow edits** - would revert the `release.yml` archive fix and the Go version bump.

## Checked rather than assumed

Two things in here could have done damage:

- **`sync-labels.yml`** runs `EndBug/label-sync` with `delete-other-labels: false`, so it will **not** delete the triage labels absent from the config. Confirmed before including it.
- **`codeql.yml`** already targets only `go` and pins Go 1.24, matching `go.mod`. (A later commit on #10 had fixed this.)

All eight workflow and config YAML files parse.

## Also

`labels.yml` gains the twelve priority/area/status labels used during triage, so the label set is reproducible from the repo rather than living only as manual edits in the web UI. 23 labels total.

`SECURITY.md` now names the real supported versions instead of a placeholder `main`/`older` table, and points reporters at the code that actually deletes things: `lib/core/file_ops.ps1`, the protected-path checks in `lib/core/base.ps1`, and the delete path in `cmd/analyze`.