### PR TITLE
test: split the Pester suite into Core, Clean and Commands (supersedes #9)

### DIFF
--- a/tests/Clean.Tests.ps1
+++ b/tests/Clean.Tests.ps1
@@ -1,0 +1,108 @@
+#!/usr/bin/env pwsh
+# WinMole - cleanup module tests (lib/clean/*) and dry-run integration tests
+# Run with: Invoke-Pester -Path .\tests\
+
+#Requires -Version 5.1
+#Requires -Modules Pester
+
+BeforeAll {
+    # Pester 5 runs each test file in its own scope, so this setup is repeated
+    # per suite. It cannot live in a helper function: dot-sourcing the modules
+    # inside one would scope those definitions to the function.
+    $script:ROOT = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+    $script:LIB_DIR = Join-Path $script:ROOT "lib"
+    $script:BIN_DIR = Join-Path $script:ROOT "bin"
+
+    . "$script:LIB_DIR\core\base.ps1"
+    . "$script:LIB_DIR\core\log.ps1"
+    . "$script:LIB_DIR\core\file_ops.ps1"
+    . "$script:LIB_DIR\clean\apps.ps1"
+
+    $script:TEST_TEMP = Join-Path $env:TEMP "WinMole_Tests_Clean_$(Get-Random)"
+    New-Item -ItemType Directory -Path $script:TEST_TEMP -Force | Out-Null
+}
+
+AfterAll {
+    if ($script:TEST_TEMP -and (Test-Path $script:TEST_TEMP)) {
+        Remove-Item -Path $script:TEST_TEMP -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ============================================================================
+# Cleanup Modules
+# ============================================================================
+
+Describe "Cleanup Modules" {
+
+    Context "Get-InstalledPrograms" {
+        It "ignores registry entries without DisplayName under strict mode" {
+            Mock Get-ItemProperty {
+                @(
+                    [pscustomobject]@{ Publisher = "NoName Publisher" }
+                    [pscustomobject]@{
+                        DisplayName     = "Named App"
+                        InstallLocation = "C:\Tools\NamedApp"
+                        Publisher       = "Named Publisher"
+                    }
+                )
+            }
+
+            Mock Get-AppxPackage { @() }
+
+            { Get-InstalledPrograms | Out-Null } | Should -Not -Throw
+            $result = Get-InstalledPrograms
+            # The mock is returned once per registry path scanned, and the entry
+            # without a DisplayName is filtered out of each batch.
+            @($result).Count | Should -Be 3
+            @($result | Where-Object { $_.DisplayName -eq "Named App" }).Count | Should -Be 3
+        }
+    }
+}
+
+# ============================================================================
+# Integration Tests
+#
+# These invoke bin/clean.ps1 for real, so they are tagged Integration and
+# excluded from the default run. WINMOLE_DRY_RUN is set so nothing is deleted.
+# ============================================================================
+
+Describe "Integration Tests" -Tag "Integration" {
+
+    Context "Dry Run Mode" {
+        It "clean respects dry run" {
+            $env:WINMOLE_DRY_RUN = "1"
+            try {
+                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -User -DryRun 2>&1 | Out-String
+                $output | Should -Not -Match "An error occurred"
+                $output | Should -Not -Match "is not recognized as"
+            }
+            finally {
+                Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue
+            }
+        }
+
+        It "clean browser dry run completes" {
+            $env:WINMOLE_DRY_RUN = "1"
+            try {
+                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -Browsers -DryRun 2>&1 | Out-String
+                $output | Should -Not -Match "is not recognized as"
+                $output | Should -Not -Match "An error occurred"
+            }
+            finally {
+                Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue
+            }
+        }
+
+        It "clean developer dry run completes" {
+            $env:WINMOLE_DRY_RUN = "1"
+            try {
+                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -Dev -DryRun 2>&1 | Out-String
+                $output | Should -Not -Match "is not recognized as"
+                $output | Should -Not -Match "An error occurred"
+            }
+            finally {
+                Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}

--- a/tests/Commands.Tests.ps1
+++ b/tests/Commands.Tests.ps1
@@ -1,0 +1,105 @@
+#!/usr/bin/env pwsh
+# WinMole - command entry point tests and repo-wide script validation
+# Run with: Invoke-Pester -Path .\tests\
+
+#Requires -Version 5.1
+#Requires -Modules Pester
+
+BeforeAll {
+    # Pester 5 runs each test file in its own scope, so this setup is repeated
+    # per suite. It cannot live in a helper function: dot-sourcing the modules
+    # inside one would scope those definitions to the function.
+    $script:ROOT = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+    $script:LIB_DIR = Join-Path $script:ROOT "lib"
+    $script:BIN_DIR = Join-Path $script:ROOT "bin"
+
+    . "$script:LIB_DIR\core\base.ps1"
+    . "$script:LIB_DIR\core\log.ps1"
+    . "$script:LIB_DIR\core\file_ops.ps1"
+
+    $script:TEST_TEMP = Join-Path $env:TEMP "WinMole_Tests_Commands_$(Get-Random)"
+    New-Item -ItemType Directory -Path $script:TEST_TEMP -Force | Out-Null
+}
+
+AfterAll {
+    if ($script:TEST_TEMP -and (Test-Path $script:TEST_TEMP)) {
+        Remove-Item -Path $script:TEST_TEMP -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ============================================================================
+# Script Validation
+# ============================================================================
+
+Describe "Script Validation" {
+
+    Context "PowerShell Scripts Syntax" {
+
+        BeforeDiscovery {
+            $rootDir = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+            $script:AllScripts = Get-ChildItem -Path $rootDir -Include "*.ps1" -Recurse
+        }
+
+        It "validates: <_.Name>" -ForEach $AllScripts {
+            $parseErrors = $null
+            $null = [System.Management.Automation.Language.Parser]::ParseFile(
+                $_.FullName,
+                [ref]$null,
+                [ref]$parseErrors
+            )
+            $parseErrors.Count | Should -Be 0
+        }
+    }
+}
+
+# ============================================================================
+# Command Entry Points
+# ============================================================================
+
+Describe "Commands" {
+
+    Context "winmole.ps1" {
+        It "exists at root" {
+            Test-Path (Join-Path $script:ROOT "winmole.ps1") | Should -Be $true
+        }
+
+        It "shows version with -Version flag" {
+            $output = & (Join-Path $script:ROOT "winmole.ps1") -Version 6>&1 | Out-String
+            $output | Should -Match "WinMole"
+        }
+
+        It "shows help with -ShowHelp flag" {
+            $output = & (Join-Path $script:ROOT "winmole.ps1") -ShowHelp 6>&1 | Out-String
+            $output | Should -Match "COMMANDS"
+        }
+    }
+
+    Context "bin/clean.ps1" {
+        It "exists" {
+            Test-Path (Join-Path $script:BIN_DIR "clean.ps1") | Should -Be $true
+        }
+
+        It "shows help with -Help flag" {
+            $output = & (Join-Path $script:BIN_DIR "clean.ps1") -Help 6>&1 | Out-String
+            $output | Should -Match "USAGE"
+        }
+    }
+
+    Context "bin/purge.ps1" {
+        It "exists" {
+            Test-Path (Join-Path $script:BIN_DIR "purge.ps1") | Should -Be $true
+        }
+    }
+
+    Context "bin/optimize.ps1" {
+        It "exists" {
+            Test-Path (Join-Path $script:BIN_DIR "optimize.ps1") | Should -Be $true
+        }
+    }
+
+    Context "bin/uninstall.ps1" {
+        It "exists" {
+            Test-Path (Join-Path $script:BIN_DIR "uninstall.ps1") | Should -Be $true
+        }
+    }
+}

--- a/tests/Core.Tests.ps1
+++ b/tests/Core.Tests.ps1
@@ -1,90 +1,90 @@
 #!/usr/bin/env pwsh
-# WinMole Pester Tests
+# WinMole - core library tests (base.ps1, file_ops.ps1, log.ps1)
 # Run with: Invoke-Pester -Path .\tests\
 
 #Requires -Version 5.1
 #Requires -Modules Pester
 
 BeforeAll {
-    # Get the root directory
+    # Pester 5 runs each test file in its own scope, so this setup is repeated
+    # per suite rather than shared. It cannot be factored into a helper function:
+    # dot-sourcing the modules inside a function would scope those definitions to
+    # the function and lose them on return.
     $script:ROOT = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
     $script:LIB_DIR = Join-Path $script:ROOT "lib"
     $script:BIN_DIR = Join-Path $script:ROOT "bin"
-    
-    # Import core modules
+
     . "$script:LIB_DIR\core\base.ps1"
     . "$script:LIB_DIR\core\log.ps1"
     . "$script:LIB_DIR\core\file_ops.ps1"
-    
-    # Create temp directory for tests
-    $script:TEST_TEMP = Join-Path $env:TEMP "WinMole_Tests_$(Get-Random)"
+
+    $script:TEST_TEMP = Join-Path $env:TEMP "WinMole_Tests_Core_$(Get-Random)"
     New-Item -ItemType Directory -Path $script:TEST_TEMP -Force | Out-Null
 }
 
 AfterAll {
-    # Cleanup temp directory
-    if (Test-Path $script:TEST_TEMP) {
+    if ($script:TEST_TEMP -and (Test-Path $script:TEST_TEMP)) {
         Remove-Item -Path $script:TEST_TEMP -Recurse -Force -ErrorAction SilentlyContinue
     }
 }
 
 # ============================================================================
-# Core Module Tests
+# base.ps1
 # ============================================================================
 
 Describe "Core Module - base.ps1" {
-    
+
     Context "Format-ByteSize" {
         It "formats bytes correctly" {
             Format-ByteSize 512 | Should -Be "512 B"
         }
-        
+
         It "formats kilobytes correctly" {
             Format-ByteSize 1024 | Should -Be "1.0 KB"
             Format-ByteSize 2048 | Should -Be "2.0 KB"
         }
-        
+
         It "formats megabytes correctly" {
             Format-ByteSize (1024 * 1024) | Should -Be "1.0 MB"
             Format-ByteSize (1024 * 1024 * 5.5) | Should -Be "5.5 MB"
         }
-        
+
         It "formats gigabytes correctly" {
             Format-ByteSize (1024 * 1024 * 1024) | Should -Be "1.0 GB"
         }
-        
+
         It "handles zero" {
             Format-ByteSize 0 | Should -Be "0 B"
         }
     }
-    
+
     Context "Test-ProtectedPath" {
         It "protects Windows directory" {
             Test-ProtectedPath "C:\Windows" | Should -Be $true
             Test-ProtectedPath "C:\Windows\System32" | Should -Be $true
         }
-        
+
         It "protects Program Files" {
             Test-ProtectedPath "C:\Program Files" | Should -Be $true
             Test-ProtectedPath "C:\Program Files (x86)" | Should -Be $true
         }
-        
+
         It "allows temp directories" {
             Test-ProtectedPath $env:TEMP | Should -Be $false
         }
-        
+
         It "allows user AppData" {
             $testPath = Join-Path $env:LOCALAPPDATA "SomeApp\Cache"
             Test-ProtectedPath $testPath | Should -Be $false
         }
     }
-    
+
     Context "Test-IsAdmin" {
         It "returns a boolean" {
             Test-IsAdmin | Should -BeOfType [bool]
         }
     }
-    
+
     Context "Get-WindowsVersion" {
         It "returns version info" {
             $info = Get-WindowsVersion
@@ -96,225 +96,107 @@ Describe "Core Module - base.ps1" {
 }
 
 # ============================================================================
-# File Operations Tests
+# file_ops.ps1
 # ============================================================================
 
 Describe "File Operations - file_ops.ps1" {
-    
+
     BeforeEach {
-        # Create test files and directories
         $script:testDir = Join-Path $script:TEST_TEMP "fileops_$(Get-Random)"
         New-Item -ItemType Directory -Path $script:testDir -Force | Out-Null
     }
-    
+
     AfterEach {
         if (Test-Path $script:testDir) {
             Remove-Item -Path $script:testDir -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
-    
+
     Context "Remove-SafeItem" {
         It "removes a regular file" {
             $testFile = Join-Path $script:testDir "test.txt"
             Set-Content -Path $testFile -Value "test"
-            
+
             Remove-SafeItem -Path $testFile
-            
+
             Test-Path $testFile | Should -Be $false
         }
-        
+
         It "removes an empty directory" {
             $testSubDir = Join-Path $script:testDir "subdir"
             New-Item -ItemType Directory -Path $testSubDir -Force | Out-Null
-            
+
             Remove-SafeItem -Path $testSubDir
-            
+
             Test-Path $testSubDir | Should -Be $false
         }
-        
+
         It "removes a directory with contents recursively" {
             $testSubDir = Join-Path $script:testDir "subdir"
             New-Item -ItemType Directory -Path $testSubDir -Force | Out-Null
             Set-Content -Path (Join-Path $testSubDir "file.txt") -Value "test"
-            
+
             Remove-SafeItem -Path $testSubDir -Recurse
-            
+
             Test-Path $testSubDir | Should -Be $false
         }
-        
+
         It "skips protected paths" {
-            # This should not actually try to delete Windows directory
-            # Remove-SafeItem internally checks and returns $false for protected paths
+            # Remove-SafeItem checks internally and returns $false for protected
+            # paths, so this never attempts to delete the Windows directory.
             $result = Remove-SafeItem -Path "C:\Windows"
             $result | Should -Be $false
         }
-        
+
         It "handles non-existent paths gracefully" {
             $nonExistent = Join-Path $script:testDir "nonexistent"
             { Remove-SafeItem -Path $nonExistent } | Should -Not -Throw
         }
     }
-    
+
     Context "Remove-OldFiles" {
         It "removes files older than specified days" {
-            # Create old file (modify timestamp)
             $oldFile = Join-Path $script:testDir "old.txt"
             Set-Content -Path $oldFile -Value "old"
             (Get-Item $oldFile).LastWriteTime = (Get-Date).AddDays(-10)
-            
-            # Create new file
+
             $newFile = Join-Path $script:testDir "new.txt"
             Set-Content -Path $newFile -Value "new"
-            
+
             Remove-OldFiles -Path $script:testDir -Days 5 -Pattern "*.txt"
-            
+
             Test-Path $oldFile | Should -Be $false
             Test-Path $newFile | Should -Be $true
         }
     }
-    
+
     Context "Remove-EmptyDirectories" {
         It "removes empty directories" {
             $emptyDir = Join-Path $script:testDir "empty"
             New-Item -ItemType Directory -Path $emptyDir -Force | Out-Null
-            
+
             Remove-EmptyDirectories -Path $script:testDir
-            
+
             Test-Path $emptyDir | Should -Be $false
         }
-        
+
         It "preserves directories with content" {
             $contentDir = Join-Path $script:testDir "withcontent"
             New-Item -ItemType Directory -Path $contentDir -Force | Out-Null
             Set-Content -Path (Join-Path $contentDir "file.txt") -Value "test"
-            
+
             Remove-EmptyDirectories -Path $script:testDir
-            
+
             Test-Path $contentDir | Should -Be $true
         }
     }
 }
 
 # ============================================================================
-# Script Validation Tests
-# ============================================================================
-
-Describe "Script Validation" {
-    
-    Context "PowerShell Scripts Syntax" {
-        
-        BeforeDiscovery {
-            $rootDir = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
-            $script:AllScripts = Get-ChildItem -Path $rootDir -Include "*.ps1" -Recurse
-        }
-        
-        It "validates: <_.Name>" -ForEach $AllScripts {
-            $parseErrors = $null
-            $null = [System.Management.Automation.Language.Parser]::ParseFile(
-                $_.FullName,
-                [ref]$null,
-                [ref]$parseErrors
-            )
-            $parseErrors.Count | Should -Be 0
-        }
-    }
-}
-
-# ============================================================================
-# Command Tests
-# ============================================================================
-
-Describe "Commands" {
-    
-    Context "winmole.ps1" {
-        It "exists at root" {
-            Test-Path (Join-Path $script:ROOT "winmole.ps1") | Should -Be $true
-        }
-        
-        It "shows version with -Version flag" {
-            $output = & (Join-Path $script:ROOT "winmole.ps1") -Version 6>&1 | Out-String
-            $output | Should -Match "WinMole"
-        }
-        
-        It "shows help with -ShowHelp flag" {
-            $output = & (Join-Path $script:ROOT "winmole.ps1") -ShowHelp 6>&1 | Out-String
-            $output | Should -Match "COMMANDS"
-        }
-    }
-    
-    Context "bin/clean.ps1" {
-        It "exists" {
-            Test-Path (Join-Path $script:BIN_DIR "clean.ps1") | Should -Be $true
-        }
-        
-        It "shows help with -Help flag" {
-            $output = & (Join-Path $script:BIN_DIR "clean.ps1") -Help 6>&1 | Out-String
-            $output | Should -Match "USAGE"
-        }
-    }
-    
-    Context "bin/purge.ps1" {
-        It "exists" {
-            Test-Path (Join-Path $script:BIN_DIR "purge.ps1") | Should -Be $true
-        }
-    }
-    
-    Context "bin/optimize.ps1" {
-        It "exists" {
-            Test-Path (Join-Path $script:BIN_DIR "optimize.ps1") | Should -Be $true
-        }
-    }
-    
-    Context "bin/uninstall.ps1" {
-        It "exists" {
-            Test-Path (Join-Path $script:BIN_DIR "uninstall.ps1") | Should -Be $true
-        }
-    }
-}
-
-# ============================================================================
-# Cleanup Module Tests
-# ============================================================================
-
-Describe "Cleanup Modules" {
-
-    BeforeAll {
-        . "$script:LIB_DIR\clean\apps.ps1"
-    }
-
-    Context "Get-InstalledPrograms" {
-        It "ignores registry entries without DisplayName under strict mode" {
-            Mock Get-ItemProperty {
-                @(
-                    [pscustomobject]@{ Publisher = "NoName Publisher" }
-                    [pscustomobject]@{
-                        DisplayName     = "Named App"
-                        InstallLocation = "C:\Tools\NamedApp"
-                        Publisher       = "Named Publisher"
-                    }
-                )
-            }
-
-            Mock Get-AppxPackage { @() }
-
-            { Get-InstalledPrograms | Out-Null } | Should -Not -Throw
-            $result = Get-InstalledPrograms
-            @($result).Count | Should -Be 3
-            @($result | Where-Object { $_.DisplayName -eq "Named App" }).Count | Should -Be 3
-        }
-    }
-}
-
-# ============================================================================
-# Progress Bar - regression tests for #18
+# log.ps1 - progress bar, regression tests for #18
 # ============================================================================
 
 Describe "Progress Bar - log.ps1" {
-
-    BeforeAll {
-        . "$script:LIB_DIR\core\base.ps1"
-        . "$script:LIB_DIR\core\log.ps1"
-    }
 
     Context "cmdlet shadowing" {
         It "does not shadow the built-in Write-Progress cmdlet" {
@@ -354,52 +236,6 @@ Describe "Progress Bar - log.ps1" {
             # parses it in argument mode and prints "+" between each part.
             $rendered = Complete-Progress 6>&1 | Out-String
             $rendered | Should -Not -Match '\+'
-        }
-    }
-}
-
-# ============================================================================
-# Integration Tests
-# ============================================================================
-
-Describe "Integration Tests" -Tag "Integration" {
-    
-    Context "Dry Run Mode" {
-        It "clean respects dry run" {
-            $env:WINMOLE_DRY_RUN = "1"
-            try {
-                # This should not actually delete anything
-                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -User -DryRun 2>&1 | Out-String
-                $output | Should -Not -Match "An error occurred"
-                $output | Should -Not -Match "is not recognized as"
-            }
-            finally {
-                Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue
-            }
-        }
-
-        It "clean browser dry run completes" {
-            $env:WINMOLE_DRY_RUN = "1"
-            try {
-                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -Browsers -DryRun 2>&1 | Out-String
-                $output | Should -Not -Match "is not recognized as"
-                $output | Should -Not -Match "An error occurred"
-            }
-            finally {
-                Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue
-            }
-        }
-
-        It "clean developer dry run completes" {
-            $env:WINMOLE_DRY_RUN = "1"
-            try {
-                $output = & (Join-Path $script:BIN_DIR "clean.ps1") -Dev -DryRun 2>&1 | Out-String
-                $output | Should -Not -Match "is not recognized as"
-                $output | Should -Not -Match "An error occurred"
-            }
-            finally {
-                Remove-Item Env:WINMOLE_DRY_RUN -ErrorAction SilentlyContinue
-            }
         }
     }
 }


### PR DESCRIPTION
Implements the intent of #9 on current master. Supersedes that PR.

## Why not rebase #9

It is 26 commits stale and deletes `tests/WinMole.Tests.ps1`, which has since gained:

- the `Get-InstalledPrograms` StrictMode test from #11
- the seven progress bar regression tests from #21

**None of its three replacement files reference either.** Merging it would silently drop that coverage, and resolving the conflict in its favour would do the same. Redoing the split on current master guarantees nothing is lost.

## The split

| File | Covers | Tests |
|---|---|---|
| `Core.Tests.ps1` | `base.ps1`, `file_ops.ps1`, `log.ps1` progress bar | 25 |
| `Clean.Tests.ps1` | `lib/clean/*` + dry-run integration tests | 1 + 3 tagged |
| `Commands.Tests.ps1` | script validation, command entry points | 31 |

## Verified complete, not assumed

- **38 `It` blocks before, 38 after.**
- Every test name present in the original is present in the split - checked by diffing the sorted name lists, not by eyeballing.
- Each of the three files also passes in isolation, so there is no hidden cross-file dependency.

The default run reports **57 passing vs the previous 55**. That is not new coverage: `Script Validation` enumerates `*.ps1` recursively, so the two additional test files and `scripts/check-commands.ps1` are now syntax-checked too.

## One deliberate bit of duplication

The per-suite setup block is repeated in each file rather than shared. A `tests/Common.ps1` helper was my first attempt and it does not work: **dot-sourcing the `lib` modules from inside a function scopes those definitions to the function**, so `Format-ByteSize` and friends vanished on return and 33 tests failed with "not recognized as a name of a cmdlet". Pester 5 also gives each test file its own scope, so there is no shared top-level `BeforeAll` to hang it on either.

Eight duplicated lines per file is the cheaper trade. Each file carries a comment recording why, so the next person does not repeat the attempt.

Each suite also now uses a distinctly named temp directory, so a failure in one cannot delete another's fixtures.