### PR TITLE
fix: redraw interactive menus in place instead of Clear-Host per keypress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to WinMole are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Interactive menus no longer stack a duplicate copy of themselves below the
+  previous one on every keypress. All menu loops (`Show-Menu`,
+  `Show-SelectionList`, purge's project picker and uninstall's app picker)
+  repainted with `Clear-Host`, which is a no-op in some terminal hosts (e.g.
+  Warp) and flickers in the rest. Frames are now redrawn in place with ANSI
+  cursor control via a new `Write-MenuFrame` helper, which also keeps the
+  banner and system info visible while navigating. (#31)
+
 ## [0.1.0] - 2026-07-28
 
 First tagged release.

--- a/bin/purge.ps1
+++ b/bin/purge.ps1
@@ -329,16 +329,18 @@ function Show-ProjectSelectionMenu {
 
     try { [Console]::CursorVisible = $false } catch { }
 
+    $frameLines = 0
+
     try {
         while ($true) {
-            Clear-Host
-
             # Header
-            Write-Host ""
-            Write-Host "$esc[1;35mSelect Projects to Clean$esc[0m"
-            Write-Host ""
-            Write-Host "$esc[90mUse: $($script:Icons.NavUp)$($script:Icons.NavDown) navigate | Space select | A select all | Enter confirm | Q quit$esc[0m"
-            Write-Host ""
+            $lines = @(
+                ""
+                "$esc[1;35mSelect Projects to Clean$esc[0m"
+                ""
+                "$esc[90mUse: $($script:Icons.NavUp)$($script:Icons.NavDown) navigate | Space select | A select all | Enter confirm | Q quit$esc[0m"
+                ""
+            )
 
             # Display projects
             $pageEnd = [Math]::Min($pageStart + $pageSize, $projectCount)
@@ -350,10 +352,6 @@ function Show-ProjectSelectionMenu {
 
                 $checkbox = if ($isSelected) { "$esc[32m[$($script:Icons.Success)]$esc[0m" } else { "[ ]" }
 
-                if ($isCurrent) {
-                    Write-Host "$esc[7m" -NoNewline
-                }
-
                 $name = $project.Name
                 if ($name.Length -gt 30) {
                     $name = $name.Substring(0, 27) + "..."
@@ -361,18 +359,18 @@ function Show-ProjectSelectionMenu {
 
                 $artifactCount = if ($null -eq $project.Artifacts) { 0 } else { @($project.Artifacts).Count }
 
-                Write-Host ("  {0} {1,-32} {2,10} ({3} items)" -f $checkbox, $name, $project.TotalSizeHuman, $artifactCount) -NoNewline
+                $row = "  {0} {1,-32} {2,10} ({3} items)" -f $checkbox, $name, $project.TotalSizeHuman, $artifactCount
 
                 if ($isCurrent) {
-                    Write-Host "$esc[0m"
+                    $lines += "$esc[7m$row$esc[0m"
                 }
                 else {
-                    Write-Host ""
+                    $lines += $row
                 }
             }
 
             # Footer
-            Write-Host ""
+            $lines += ""
             $selectedCount = $selectedIndices.Count
             if ($selectedCount -gt 0) {
                 $totalSize = 0
@@ -380,13 +378,16 @@ function Show-ProjectSelectionMenu {
                     $totalSize += $Projects[$idx].TotalSizeKB
                 }
                 $totalSizeHuman = Format-ByteSize -Bytes ($totalSize * 1024)
-                Write-Host "$esc[33mSelected:$esc[0m $selectedCount projects ($totalSizeHuman)"
+                $lines += "$esc[33mSelected:$esc[0m $selectedCount projects ($totalSizeHuman)"
             }
 
             # Page indicator
             $totalPages = [Math]::Ceiling($projectCount / $pageSize)
             $currentPage = [Math]::Floor($pageStart / $pageSize) + 1
-            Write-Host "$esc[90mPage $currentPage of $totalPages | Total: $projectCount projects$esc[0m"
+            $lines += "$esc[90mPage $currentPage of $totalPages | Total: $projectCount projects$esc[0m"
+
+            # Render in place over the previous frame
+            $frameLines = Write-MenuFrame -Lines $lines -PreviousLineCount $frameLines
 
             # Handle input
             $key = [Console]::ReadKey($true)

--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -292,21 +292,23 @@ function Show-AppSelectionMenu {
     # Hide cursor (may fail in non-interactive terminals)
     try { [Console]::CursorVisible = $false } catch { }
 
+    $frameLines = 0
+
     try {
         while ($true) {
-            Clear-Host
-
             # Header
-            Write-Host ""
-            Write-Host "$esc[1;35mSelect Applications to Uninstall$esc[0m"
-            Write-Host ""
-            Write-Host "$esc[90mUse: $($script:Icons.NavUp)$($script:Icons.NavDown) navigate | Space select | Enter confirm | Q quit | / search$esc[0m"
-            Write-Host ""
+            $lines = @(
+                ""
+                "$esc[1;35mSelect Applications to Uninstall$esc[0m"
+                ""
+                "$esc[90mUse: $($script:Icons.NavUp)$($script:Icons.NavDown) navigate | Space select | Enter confirm | Q quit | / search$esc[0m"
+                ""
+            )
 
             # Search indicator
             if ($searchTerm) {
-                Write-Host "$esc[33mSearch:$esc[0m $searchTerm ($($filteredApps.Count) matches)"
-                Write-Host ""
+                $lines += "$esc[33mSearch:$esc[0m $searchTerm ($($filteredApps.Count) matches)"
+                $lines += ""
             }
 
             # Display apps
@@ -320,11 +322,6 @@ function Show-AppSelectionMenu {
                 # Selection indicator
                 $checkbox = if ($isSelected) { "$esc[32m[$($script:Icons.Success)]$esc[0m" } else { "[ ]" }
 
-                # Highlight current
-                if ($isCurrent) {
-                    Write-Host "$esc[7m" -NoNewline  # Reverse video
-                }
-
                 # App info
                 $name = $app.Name
                 if ($name.Length -gt 40) {
@@ -336,18 +333,18 @@ function Show-AppSelectionMenu {
                     $size = "N/A"
                 }
 
-                Write-Host ("  {0} {1,-42} {2,10}" -f $checkbox, $name, $size) -NoNewline
+                $row = "  {0} {1,-42} {2,10}" -f $checkbox, $name, $size
 
                 if ($isCurrent) {
-                    Write-Host "$esc[0m"  # Reset
+                    $lines += "$esc[7m$row$esc[0m"  # Reverse video
                 }
                 else {
-                    Write-Host ""
+                    $lines += $row
                 }
             }
 
             # Footer
-            Write-Host ""
+            $lines += ""
             $selectedCount = $selectedIndices.Count
             if ($selectedCount -gt 0) {
                 $totalSize = 0
@@ -358,13 +355,16 @@ function Show-AppSelectionMenu {
                     }
                 }
                 $totalSizeHuman = Format-ByteSize -Bytes ($totalSize * 1024)
-                Write-Host "$esc[33mSelected:$esc[0m $selectedCount apps ($totalSizeHuman)"
+                $lines += "$esc[33mSelected:$esc[0m $selectedCount apps ($totalSizeHuman)"
             }
 
             # Page indicator
             $totalPages = [Math]::Ceiling($filteredApps.Count / $pageSize)
             $currentPage = [Math]::Floor($pageStart / $pageSize) + 1
-            Write-Host "$esc[90mPage $currentPage of $totalPages$esc[0m"
+            $lines += "$esc[90mPage $currentPage of $totalPages$esc[0m"
+
+            # Render in place over the previous frame
+            $frameLines = Write-MenuFrame -Lines $lines -PreviousLineCount $frameLines
 
             # Handle input
             $key = [Console]::ReadKey($true)
@@ -418,12 +418,14 @@ function Show-AppSelectionMenu {
                     return @()
                 }
                 'Oem2' {  # Forward slash
-                    # Search mode
-                    Write-Host ""
+                    # Search mode - erase the menu frame and prompt in its place
+                    $frameLines = Write-MenuFrame -Lines @() -PreviousLineCount $frameLines
                     Write-Host "Search: " -NoNewline
                     try { [Console]::CursorVisible = $true } catch { }
                     $searchTerm = Read-Host
                     try { [Console]::CursorVisible = $false } catch { }
+                    # Read-Host leaves one prompt line behind; overwrite it next frame
+                    $frameLines = 1
 
                     if ($searchTerm) {
                         $filteredApps = $Apps | Where-Object { $_.Name -like "*$searchTerm*" }

--- a/lib/core/ui.ps1
+++ b/lib/core/ui.ps1
@@ -60,6 +60,45 @@ function Move-CursorDown {
     Write-Host -NoNewline "$([char]27)[$Lines`B"
 }
 
+function Write-MenuFrame {
+    <#
+    .SYNOPSIS
+        Render a frame of an interactive menu in place
+    .DESCRIPTION
+        Writes the given lines as a single buffered block. When PreviousLineCount
+        is greater than zero, the cursor is first moved back to the start of the
+        previous frame and everything below is cleared, so the new frame
+        overwrites the old one instead of stacking below it. This avoids
+        Clear-Host, which is a no-op in some terminal hosts and causes
+        full-screen flicker in the rest.
+    .PARAMETER Lines
+        The lines making up the frame
+    .PARAMETER PreviousLineCount
+        Number of lines the previous frame occupied (0 for the first frame)
+    .OUTPUTS
+        [int] The number of lines rendered; pass it back on the next call
+    #>
+    param(
+        [array]$Lines = @(),
+        [int]$PreviousLineCount = 0
+    )
+
+    $esc = [char]27
+    $sb = [System.Text.StringBuilder]::new()
+
+    if ($PreviousLineCount -gt 0) {
+        # Cursor to start of the previous frame's first line, then clear to end of screen
+        [void]$sb.Append("$esc[${PreviousLineCount}F$esc[0J")
+    }
+
+    foreach ($line in $Lines) {
+        [void]$sb.Append([string]$line).Append("`n")
+    }
+
+    Write-Host -NoNewline $sb.ToString()
+    return @($Lines).Count
+}
+
 # ============================================================================
 # Confirmation Dialogs
 # ============================================================================
@@ -154,31 +193,35 @@ function Show-Menu {
     
     # Hide cursor
     Write-Host -NoNewline "$([char]27)[?25l"
-    
+
+    $frameLines = 0
+
     try {
         while ($true) {
-            # Clear screen and show menu
-            Clear-Host
-            
-            Write-Host ""
-            Write-Host "  ${purple}$($script:Icons.Arrow) $Title${nc}"
-            Write-Host ""
-            
+            # Build the frame and render it in place over the previous one
+            $lines = @(
+                ""
+                "  ${purple}$($script:Icons.Arrow) $Title${nc}"
+                ""
+            )
+
             for ($i = 0; $i -le $maxIndex; $i++) {
                 $option = $Options[$i]
                 $name = if ($option -is [hashtable]) { $option.Name } else { $option.ToString() }
                 $desc = if ($option -is [hashtable] -and $option.Description) { " - $($option.Description)" } else { "" }
-                
+
                 if ($i -eq $selected) {
-                    Write-Host "  ${cyan}> $name${nc}${gray}$desc${nc}"
+                    $lines += "  ${cyan}> $name${nc}${gray}$desc${nc}"
                 }
                 else {
-                    Write-Host "    $name${gray}$desc${nc}"
+                    $lines += "    $name${gray}$desc${nc}"
                 }
             }
-            
-            Write-Host ""
-            Write-Host "  ${gray}Use arrows or j/k to navigate, Enter to select, q to quit${nc}"
+
+            $lines += ""
+            $lines += "  ${gray}Use arrows or j/k to navigate, Enter to select, q to quit${nc}"
+
+            $frameLines = Write-MenuFrame -Lines $lines -PreviousLineCount $frameLines
             
             # Read key - handle both VirtualKeyCode and escape sequences
             $key = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
@@ -267,34 +310,39 @@ function Show-SelectionList {
     $nc = $script:Colors.NC
     
     Write-Host -NoNewline "$([char]27)[?25l"
-    
+
+    $frameLines = 0
+
     try {
         while ($true) {
-            Clear-Host
-            
-            Write-Host ""
-            Write-Host "  ${purple}$($script:Icons.Arrow) $Title${nc}"
+            # Build the frame and render it in place over the previous one
+            $lines = @(
+                ""
+                "  ${purple}$($script:Icons.Arrow) $Title${nc}"
+            )
             if ($MultiSelect) {
-                Write-Host "  ${gray}Space to toggle, Enter to confirm${nc}"
+                $lines += "  ${gray}Space to toggle, Enter to confirm${nc}"
             }
-            Write-Host ""
-            
+            $lines += ""
+
             for ($i = 0; $i -le $maxIndex; $i++) {
                 $item = $Items[$i]
                 $name = if ($item -is [hashtable]) { $item.Name } else { $item.ToString() }
                 $check = if ($selected[$i]) { "$($script:Icons.Success)" } else { "$($script:Icons.Empty)" }
-                
+
                 if ($i -eq $cursor) {
-                    Write-Host "  ${cyan}> ${check} $name${nc}"
+                    $lines += "  ${cyan}> ${check} $name${nc}"
                 }
                 else {
                     $checkColor = if ($selected[$i]) { $green } else { $gray }
-                    Write-Host "    ${checkColor}${check}${nc} $name"
+                    $lines += "    ${checkColor}${check}${nc} $name"
                 }
             }
-            
-            Write-Host ""
-            Write-Host "  ${gray}j/k or arrows to navigate, space to select, Enter to confirm, q to cancel${nc}"
+
+            $lines += ""
+            $lines += "  ${gray}j/k or arrows to navigate, space to select, Enter to confirm, q to cancel${nc}"
+
+            $frameLines = Write-MenuFrame -Lines $lines -PreviousLineCount $frameLines
             
             $key = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
             


### PR DESCRIPTION
Fixes #31

## Problem

Every interactive menu loop repainted by calling `Clear-Host` on each keypress. In terminal hosts where `Clear-Host` is effectively a no-op inside a running command (e.g. Warp's block model), each frame stacked below the previous one, flooding the terminal with duplicate menus. Where it did work, it flickered the whole screen and erased the banner/system info.

Affected: `Show-Menu` and `Show-SelectionList` in `lib/core/ui.ps1`, `Show-ProjectSelectionMenu` in `bin/purge.ps1`, `Show-AppSelectionMenu` in `bin/uninstall.ps1`.

## Fix

New `Write-MenuFrame` helper in `lib/core/ui.ps1`:

- writes each frame as a **single buffered block** (one `Write-Host` call — less flicker)
- on redraws, moves the cursor to the start of the previous frame (`ESC[nF`) and clears from there to end of screen (`ESC[0J`), then writes the new frame — so the menu updates **in place** in any VT-capable terminal, independent of `Clear-Host` support
- returns the rendered line count, which the caller passes back on the next frame

All four menu loops now build a `$lines` array and render through it. Side benefits:

- the WINMOLE banner and system info stay visible while navigating the main menu
- the uninstall search prompt (`/`) erases the menu frame before prompting and hands its own line back to the counter, so it no longer leaves stray lines behind

## Testing

- Syntax parse clean on all three modified scripts
- `tests/Core.Tests.ps1`: 25 passed, 0 failed
- Smoke-tested `Write-MenuFrame`: correct line counts and `ESC[3F ESC[0J` emitted between frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)