### PR TITLE
Fix garbled text on CJK Windows (Korean/Japanese/Chinese)

### DIFF
--- a/bin/analyze.ps1
+++ b/bin/analyze.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # WinMole - Disk Space Analyzer
 # Wrapper for Go TUI application
 

--- a/bin/analyze.ps1
+++ b/bin/analyze.ps1
@@ -191,3 +191,6 @@ catch {
     Write-Host ""
     exit 1
 }
+finally {
+    Restore-WinMoleConsoleEncoding
+}

--- a/bin/clean.ps1
+++ b/bin/clean.ps1
@@ -424,4 +424,5 @@ try {
 }
 finally {
     Clear-TempFiles
+    Restore-WinMoleConsoleEncoding
 }

--- a/bin/clean.ps1
+++ b/bin/clean.ps1
@@ -1,4 +1,4 @@
-# WinMole - Clean Command
+﻿# WinMole - Clean Command
 # Deep cleanup orchestrator for Windows
 
 #Requires -Version 5.1

--- a/bin/optimize.ps1
+++ b/bin/optimize.ps1
@@ -1,4 +1,4 @@
-# WinMole - Optimize Command
+﻿# WinMole - Optimize Command
 # System optimization, health checks, and repairs for Windows
 
 #Requires -Version 5.1

--- a/bin/optimize.ps1
+++ b/bin/optimize.ps1
@@ -791,4 +791,9 @@ function Main {
 }
 
 # Run main
-Main
+try {
+    Main
+}
+finally {
+    Restore-WinMoleConsoleEncoding
+}

--- a/bin/purge.ps1
+++ b/bin/purge.ps1
@@ -1,4 +1,4 @@
-# WinMole - Purge Command
+﻿# WinMole - Purge Command
 # Aggressive cleanup of project build artifacts
 
 #Requires -Version 5.1

--- a/bin/purge.ps1
+++ b/bin/purge.ps1
@@ -617,4 +617,9 @@ function Main {
 }
 
 # Run main
-Main
+try {
+    Main
+}
+finally {
+    Restore-WinMoleConsoleEncoding
+}

--- a/bin/status.ps1
+++ b/bin/status.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # WinMole - System Status Monitor
 # Wrapper for Go TUI application
 

--- a/bin/status.ps1
+++ b/bin/status.ps1
@@ -166,3 +166,6 @@ catch {
     Write-Host ""
     exit 1
 }
+finally {
+    Restore-WinMoleConsoleEncoding
+}

--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -629,4 +629,9 @@ function Main {
 }
 
 # Run main
-Main
+try {
+    Main
+}
+finally {
+    Restore-WinMoleConsoleEncoding
+}

--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -1,4 +1,4 @@
-# WinMole - Uninstall Command
+﻿# WinMole - Uninstall Command
 # Interactive application uninstaller for Windows
 
 #Requires -Version 5.1

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # WinMole Installer
 # Installs WinMole to the system and adds to PATH
 
@@ -14,6 +14,14 @@ param(
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+
+# Force UTF-8 console output so the banner renders correctly on CJK Windows
+# (PowerShell 5.1 defaults to the ANSI/OEM codepage, e.g. CP949)
+try {
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    $OutputEncoding = [System.Text.Encoding]::UTF8
+}
+catch { }
 
 # ============================================================================
 # Configuration

--- a/install.ps1
+++ b/install.ps1
@@ -16,10 +16,15 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
 # Force UTF-8 console output so the banner renders correctly on CJK Windows
-# (PowerShell 5.1 defaults to the ANSI/OEM codepage, e.g. CP949)
+# (PowerShell 5.1 defaults to the ANSI/OEM codepage, e.g. CP949).
+# Save the previous encodings so they can be restored on exit.
+$script:WinMoleOriginalConsoleOutputEncoding = $null
+$script:WinMoleOriginalOutputEncoding = $null
 try {
+    $script:WinMoleOriginalConsoleOutputEncoding = [Console]::OutputEncoding
+    $script:WinMoleOriginalOutputEncoding = $global:OutputEncoding
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-    $OutputEncoding = [System.Text.Encoding]::UTF8
+    $global:OutputEncoding = [System.Text.Encoding]::UTF8
 }
 catch { }
 
@@ -426,4 +431,15 @@ catch {
     Write-Error "Installation failed: $_"
     Write-Host ""
     exit 1
+}
+finally {
+    try {
+        if ($null -ne $script:WinMoleOriginalConsoleOutputEncoding) {
+            [Console]::OutputEncoding = $script:WinMoleOriginalConsoleOutputEncoding
+        }
+        if ($null -ne $script:WinMoleOriginalOutputEncoding) {
+            $global:OutputEncoding = $script:WinMoleOriginalOutputEncoding
+        }
+    }
+    catch { }
 }

--- a/lib/clean/apps.ps1
+++ b/lib/clean/apps.ps1
@@ -1,4 +1,4 @@
-# WinMole - Application-Specific Cleanup Module
+﻿# WinMole - Application-Specific Cleanup Module
 # Cleans leftover data from uninstalled apps and app-specific caches
 
 #Requires -Version 5.1

--- a/lib/clean/caches.ps1
+++ b/lib/clean/caches.ps1
@@ -1,4 +1,4 @@
-# WinMole - Cache Cleanup Module
+﻿# WinMole - Cache Cleanup Module
 # Cleans Windows and application caches
 
 #Requires -Version 5.1

--- a/lib/clean/dev.ps1
+++ b/lib/clean/dev.ps1
@@ -1,4 +1,4 @@
-# WinMole - Developer Tools Cleanup Module
+﻿# WinMole - Developer Tools Cleanup Module
 # Cleans development tool caches and build artifacts
 
 #Requires -Version 5.1

--- a/lib/clean/system.ps1
+++ b/lib/clean/system.ps1
@@ -1,4 +1,4 @@
-# WinMole - System Cleanup Module
+﻿# WinMole - System Cleanup Module
 # Cleans Windows system files that require administrator access
 
 #Requires -Version 5.1

--- a/lib/clean/user.ps1
+++ b/lib/clean/user.ps1
@@ -1,4 +1,4 @@
-# WinMole - User Cleanup Module
+﻿# WinMole - User Cleanup Module
 # Cleans user-level temporary files, caches, and downloads
 
 #Requires -Version 5.1

--- a/lib/core/base.ps1
+++ b/lib/core/base.ps1
@@ -10,12 +10,35 @@ if ((Get-Variable -Name 'WINMOLE_BASE_LOADED' -Scope Script -ErrorAction Silentl
 $script:WINMOLE_BASE_LOADED = $true
 
 # Force UTF-8 console output so box-drawing/icon characters render correctly
-# on CJK Windows (PowerShell 5.1 defaults to the ANSI/OEM codepage, e.g. CP949)
+# on CJK Windows (PowerShell 5.1 defaults to the ANSI/OEM codepage, e.g. CP949).
+# The previous encodings are saved so entry points can restore them on exit
+# via Restore-WinMoleConsoleEncoding (avoids leaving the process-wide console
+# encoding changed after WinMole returns).
+$script:WinMoleOriginalConsoleOutputEncoding = $null
+$script:WinMoleOriginalOutputEncoding = $null
 try {
+    $script:WinMoleOriginalConsoleOutputEncoding = [Console]::OutputEncoding
+    $script:WinMoleOriginalOutputEncoding = $global:OutputEncoding
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-    $OutputEncoding = [System.Text.Encoding]::UTF8
+    $global:OutputEncoding = [System.Text.Encoding]::UTF8
 }
 catch { }
+
+function Restore-WinMoleConsoleEncoding {
+    <#
+    .SYNOPSIS
+        Restore the console output encoding that was active before WinMole ran.
+    #>
+    try {
+        if ($null -ne $script:WinMoleOriginalConsoleOutputEncoding) {
+            [Console]::OutputEncoding = $script:WinMoleOriginalConsoleOutputEncoding
+        }
+        if ($null -ne $script:WinMoleOriginalOutputEncoding) {
+            $global:OutputEncoding = $script:WinMoleOriginalOutputEncoding
+        }
+    }
+    catch { }
+}
 
 # ============================================================================
 # Color Definitions (ANSI escape codes for modern terminals)

--- a/lib/core/base.ps1
+++ b/lib/core/base.ps1
@@ -1,4 +1,4 @@
-# WinMole - Base Definitions and Utilities
+﻿# WinMole - Base Definitions and Utilities
 # Core definitions, constants, and basic utility functions used by all modules
 
 #Requires -Version 5.1
@@ -8,6 +8,14 @@ $ErrorActionPreference = "Stop"
 # Prevent multiple sourcing
 if ((Get-Variable -Name 'WINMOLE_BASE_LOADED' -Scope Script -ErrorAction SilentlyContinue) -and $script:WINMOLE_BASE_LOADED) { return }
 $script:WINMOLE_BASE_LOADED = $true
+
+# Force UTF-8 console output so box-drawing/icon characters render correctly
+# on CJK Windows (PowerShell 5.1 defaults to the ANSI/OEM codepage, e.g. CP949)
+try {
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    $OutputEncoding = [System.Text.Encoding]::UTF8
+}
+catch { }
 
 # ============================================================================
 # Color Definitions (ANSI escape codes for modern terminals)

--- a/lib/core/common.ps1
+++ b/lib/core/common.ps1
@@ -1,4 +1,4 @@
-# WinMole - Common Functions Library
+﻿# WinMole - Common Functions Library
 # Main entry point that loads all core modules
 
 #Requires -Version 5.1

--- a/lib/core/file_ops.ps1
+++ b/lib/core/file_ops.ps1
@@ -1,4 +1,4 @@
-# WinMole - Safe File Operations Module
+﻿# WinMole - Safe File Operations Module
 # Provides safe file deletion and manipulation functions with protection checks
 
 #Requires -Version 5.1

--- a/lib/core/log.ps1
+++ b/lib/core/log.ps1
@@ -1,4 +1,4 @@
-# WinMole - Logging Module
+﻿# WinMole - Logging Module
 # Provides consistent logging functions with colors and icons
 
 #Requires -Version 5.1

--- a/lib/core/ui.ps1
+++ b/lib/core/ui.ps1
@@ -1,4 +1,4 @@
-# WinMole - UI Module
+﻿# WinMole - UI Module
 # Provides interactive UI components (menus, confirmations, etc.)
 
 #Requires -Version 5.1

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # WinMole Build Script
 # Builds Go binaries and validates PowerShell scripts
 

--- a/scripts/check-commands.ps1
+++ b/scripts/check-commands.ps1
@@ -1,4 +1,4 @@
-# WinMole - Static command resolution check
+﻿# WinMole - Static command resolution check
 #
 # PowerShell resolves command names at call time, so a call to a function that
 # does not exist, or a call passing a parameter that was never declared, is

--- a/tests/Clean.Tests.ps1
+++ b/tests/Clean.Tests.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # WinMole - cleanup module tests (lib/clean/*) and dry-run integration tests
 # Run with: Invoke-Pester -Path .\tests\
 

--- a/tests/Commands.Tests.ps1
+++ b/tests/Commands.Tests.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # WinMole - command entry point tests and repo-wide script validation
 # Run with: Invoke-Pester -Path .\tests\
 

--- a/tests/Core.Tests.ps1
+++ b/tests/Core.Tests.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # WinMole - core library tests (base.ps1, file_ops.ps1, log.ps1)
 # Run with: Invoke-Pester -Path .\tests\
 

--- a/winmole.ps1
+++ b/winmole.ps1
@@ -321,4 +321,5 @@ catch {
 }
 finally {
     Clear-TempFiles
+    Restore-WinMoleConsoleEncoding
 }

--- a/winmole.ps1
+++ b/winmole.ps1
@@ -1,4 +1,4 @@
-#!/usr/bin/env pwsh
+﻿#!/usr/bin/env pwsh
 # WinMole - Windows System Maintenance Toolkit
 # Main CLI entry point
 


### PR DESCRIPTION
## Problem

On Korean/Japanese/Chinese Windows, WinMole's banners and icons render as garbled text (`╦ ║ ━ █` etc. show as mojibake).

Fixes #36

## Root cause

PowerShell 5.1 on CJK Windows defaults to the ANSI/OEM codepage (e.g. **CP949** on Korean Windows). All `.ps1` scripts in this repo are saved as **UTF-8 without a BOM**, so PowerShell 5.1 misreads them as ANSI and the multi-byte UTF-8 characters get corrupted — both at parse time and at console output time.

## Fix

1. **Add UTF-8 BOM to all 23 `.ps1` files** (scripts, lib modules, bin commands, tests) so PowerShell 5.1 parses them as UTF-8 regardless of system locale.
2. **Force UTF-8 console output at runtime** in `lib/core/base.ps1` (loaded by every command via `common.ps1`) and `install.ps1` (standalone):
   ```powershell
   [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
   $OutputEncoding = [System.Text.Encoding]::UTF8
   ```
3. **Restore the original console encoding on exit** (addressing review P1): `base.ps1` saves the previous `[Console]::OutputEncoding` / `$OutputEncoding` and provides `Restore-WinMoleConsoleEncoding`; every entry point (`winmole.ps1`, all `bin/*.ps1`, `install.ps1`) calls it in a `finally` block, so WinMole no longer leaves the session-wide console encoding changed after it returns.

## Verification

- All 23 `.ps1` files confirmed to start with `EF BB BF` (UTF-8 BOM)
- No non-ASCII content changes — pure encoding + small runtime blocks
- Tested on Korean Windows (Windows 10, PowerShell 5.1): banner and icons render correctly, and the console encoding is restored after WinMole exits
