### PR TITLE
docs: fix branch reference main → master in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,13 +161,13 @@ Describe "Remove-SafeItem" {
 
 ## Pull Requests
 
-> **Important:** Please submit PRs to the `main` branch.
+> **Important:** Please submit PRs to the `master` branch (the repository default).
 
-1. Fork and create branch from `main`
+1. Fork and create branch from `master`
 2. Make your changes
 3. Run tests: `Invoke-Pester -Path .\tests\`
 4. Commit with descriptive message
-5. Open PR targeting `main`
+5. Open PR targeting `master`
 
 ### Commit Messages
 


### PR DESCRIPTION
## Problem

CONTRIBUTING.md instructs contributors to submit PRs to the `main` branch, but the repository's default branch is **`master`** — there is no `main` branch. This confuses contributors when selecting the base branch for a PR.

## Fix

Update the Pull Requests section of CONTRIBUTING.md to reference `master` (the repository default):

- "Please submit PRs to the `master` branch (the repository default)."
- "Fork and create branch from `master`"
- "Open PR targeting `master`"

## Verification

- `gh repo view bhadraagada/winmole --json defaultBranchRef` → `master`
- `git ls-remote --heads origin` → no `main` branch exists
- Existing merged PRs all target `master`
