### PR TITLE
fix(clean): wrap orphaned app data in @() to prevent StrictMode .Count throw

### DIFF
--- a/lib/clean/apps.ps1
+++ b/lib/clean/apps.ps1
@@ -35,7 +35,7 @@ function Get-InstalledPrograms {
     foreach ($path in $registryPaths) {
         $items = Get-ItemProperty -Path $path -ErrorAction SilentlyContinue |
                  Where-Object {
-                     $_.PSObject.Properties.Match('DisplayName').Count -gt 0 -and
+                     @($_.PSObject.Properties.Match('DisplayName')).Count -gt 0 -and
                      -not [string]::IsNullOrWhiteSpace($_.DisplayName)
                  } |
                  Select-Object DisplayName, InstallLocation, Publisher
@@ -141,7 +141,7 @@ function Clear-OrphanedAppData {
     
     Start-Section "Orphaned app data"
     
-    $orphaned = Find-OrphanedAppData -DaysOld $DaysOld
+    $orphaned = @(Find-OrphanedAppData -DaysOld $DaysOld)
     
     if ($orphaned.Count -eq 0) {
         Write-Info "No orphaned app data found"
@@ -150,7 +150,7 @@ function Clear-OrphanedAppData {
     }
     
     # Filter by size (only clean if > 10MB to avoid noise)
-    $significantOrphans = $orphaned | Where-Object { $_.Size -gt 10MB }
+    $significantOrphans = @($orphaned | Where-Object { $_.Size -gt 10MB })
     
     if ($significantOrphans.Count -gt 0) {
         $totalSize = ($significantOrphans | Measure-Object -Property Size -Sum).Sum


### PR DESCRIPTION
## Summary

Fixes the `Clean -> Orphaned Apps` crash: **"An error occurred: 이 개체에서 'Count' 속성을 찾을 수 없습니다. 해당 속성이 있는지 검증하십시오."** (PowerShell `PropertyNotFoundException`).

## Root cause

`lib/clean/apps.ps1` runs under `Set-StrictMode -Version Latest`. When no orphaned folders are found, `Find-OrphanedAppData` returns an empty `@()` which PowerShell **unrolls through the pipeline into `$null`**. Then `$orphaned.Count` on `$null` throws `PropertyNotFoundException` — crashing the flow **exactly when there is nothing to clean**.

The same scalar-vs-null hazard applies to `$significantOrphans` (single match → scalar, no match → `$null`).

## Fix (3 lines)

| Line | Before | After |
|------|--------|-------|
| 38 | `$_.PSObject.Properties.Match('DisplayName').Count -gt 0` | `@($_.PSObject.Properties.Match('DisplayName')).Count -gt 0` |
| 146 | `$orphaned = Find-OrphanedAppData -DaysOld $DaysOld` | `$orphaned = @(Find-OrphanedAppData -DaysOld $DaysOld)` |
| 155 | `$significantOrphans = $orphaned \| Where-Object { ... }` | `$significantOrphans = @($orphaned \| Where-Object { ... })` |

Wrapping in `@()` forces an array, so `.Count` always exists under StrictMode.

## Verification (Windows PowerShell 5.1, READ-ONLY)

Repro was executed on a real Windows host with **no deletion path ever executed** (registry + AppData scan only):

- Original line-146 replica (`$orphaned.Count` on `$null`): **THROWS** `PropertyNotFoundException` — exact operator error reproduced
- Patched `Get-InstalledPrograms`: 407 programs, identical to original (no side effects)
- Patched `Find-OrphanedAppData` + line-146/155 replicas: **0 orphans, no throw**
- `PSObject` without `DisplayName` → `Match().Count` returns 0, no throw (L38 safe, wrapped defensively)

Evidence file: `winmole-repro-output.txt` (58 lines, PART 1 primitives → PART 2 repro → PART 3 patched verification).

## Notes

- READ-ONLY constraints honored throughout; `Clear-OrphanedAppData` (deletion) never invoked.
- Matches the repo's own AGENTS.md rule #3: "Null array counts: Wrap in `@()` before `.Count`".
